### PR TITLE
Joint Distributions Bugfix

### DIFF
--- a/src/components/JointDistributions/JDSimulation.js
+++ b/src/components/JointDistributions/JDSimulation.js
@@ -34,8 +34,8 @@ export default function JDSimulation() {
   const generate = () => {
     const newCorrelation = ((abs(+correlation) === 1) ? (0.999999 * correlation) : correlation);
     const covariance = newCorrelation * parentSD * childSD;
-    const temp = [[parentSD ** 2, covariance], [covariance, childSD ** 2]];
-    const distribution = MultivariateNormal([+parentMean, +childMean], temp);
+    const covMatrix = [[parentSD ** 2, covariance], [covariance, childSD ** 2]];
+    const distribution = MultivariateNormal([+parentMean, +childMean], covMatrix);
 
     const jointSeries = [];
     for (let i = 0; i < 1000; i++) {


### PR DESCRIPTION
Found the error; we were comparing an `int` to a `string` so adjusting from `1` to `0.99999` never actually happened. I also took the opportunity to cleanup the code a bit (we didn't need to store `covariance` in state).

closes #20 