### PR TITLE
fix highlight bug and enable zoom

### DIFF
--- a/src/components/ConfidenceIntervals/CISimulation.js
+++ b/src/components/ConfidenceIntervals/CISimulation.js
@@ -145,7 +145,6 @@ export default function CISimulation({ popType, populationSize }) {
           </Alert>
         }
       </Row>
-      <Button onClick={() => unselect()}>unselect</Button>
     </Collapsable>
   );
 }

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
@@ -60,14 +60,26 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
       chart: {
         type: 'columnrange',
         inverted: true,
-        animation: false
+        animation: false,
+        zoomType: "xy",
+        events: {
+          // hack to allow zoom
+          selection: (event) => {
+            event.target.series.forEach((series) => {
+              series.data.forEach((point) => {
+                point.select(false, false)
+              })
+            })
+          }
+        }
       },
       plotOptions: {
         series: {
           point: {
             events: {
               click() {
-                setSelected(this)
+                setSelected(this);
+                this.select(false, false);
               }
             }
           },


### PR DESCRIPTION
I used a hack to fix the pesky highlighting bug, which also allowed me to re-enable the zoom feature for the Confidence Interval chart