### PR TITLE
Fix spacing

### DIFF
--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -71,25 +71,25 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
             {popType === "Uniform" && <p>Behavioral economists studying loss aversion design a lottery among 2000 participants where each amount between -10 and +10 is equally likely.  We plotted the winnings and losses below.</p>}
           </Alert>
         </Row>
-          <Row >
-            <Col lg="2">
-              <PopTable
-                samples={sampled}
-                popArray={popArray}
-                popType={popType}
-              />
-            </Col>
-            <Col lg="8">
-              <DotPlot
-                series={series}
-                title={`${title} <br /> Population Mean: ${_.round(popMean, 2)}`}
-                xMin={xminval}
-                xMax={xmaxval}
-                yMax={ymaxval}
-                xLabel={xLabel}
-              />
-            </Col>
-          </Row>
+        <Row>
+          <Col lg={2} md={12}>
+            <PopTable
+              samples={sampled}
+              popArray={popArray}
+              popType={popType}
+            />
+          </Col>
+          <Col lg={10}>
+            <DotPlot
+              series={series}
+              title={`${title} <br /> Population Mean: ${_.round(popMean, 2)}`}
+              xMin={xminval}
+              xMax={xmaxval}
+              yMax={ymaxval}
+              xLabel={xLabel}
+            />
+          </Col>
+        </Row>
       </Container>
     </div>
   );

--- a/src/components/ConfidenceIntervals/CISimulation.js
+++ b/src/components/ConfidenceIntervals/CISimulation.js
@@ -6,7 +6,7 @@ import ConfidenceIntervalsChart from "./ConfidenceIntervalsChart.js";
 import ManySamplesInput from "./ManySamplesInput.js";
 import SamplesTable from "./SamplesTable.js";
 import { dataFromDistribution, populationMean } from "../../lib/stats-utils.js";
-import { Row, Col, Alert, Button } from "reactstrap";
+import { Row, Col, Alert } from "reactstrap";
 import PopulationChart from "./PopulationChart.js";
 import _ from "lodash";
 import { std } from "mathjs";
@@ -100,7 +100,7 @@ export default function CISimulation({ popType, populationSize }) {
         />
       </Row>
       <br/>
-      <Row>
+      <Row md={1} lg={2}>
         <Col>
           <PopulationChart
             popArray={popArray}
@@ -123,19 +123,19 @@ export default function CISimulation({ popType, populationSize }) {
         </Col>
       </Row>
       <Row>
-        <Col>
+        <Col lg={12} xl={5}>
           <ManySamplesInput
             population={popArray}
             addSamples={generateSamples}
             clear={clear}
           />
         </Col>
-        <Col>
+        <Col lg={12} xl={7}>
           <SamplesTable samples={samples} setSelected={selectPoint}/>
         </Col>
       </Row>
       <br/>
-      <Row lg="12">
+      <Row>
         {
           (samples.length > 0) &&
           <Alert color="info" style={{margin:'auto'}}>

--- a/src/components/JointDistributions/JDSimulation.js
+++ b/src/components/JointDistributions/JDSimulation.js
@@ -70,13 +70,13 @@ export default function JDSimulation() {
   return (
     <Container fluid>
       <Row>
-        <Col>
+        <Col xl={4} md={6} xs={12} style={{padding: 10}}>
           <MeanSDInput title="Parent" mean={parentMean} setMean={setParentMean} sd={parentSD} setSD={setParentSD}/>
         </Col>
-        <Col>
+        <Col xl={4} md={6} xs={12} style={{padding: 10}}>
           <MeanSDInput title="Child" mean={childMean} setMean={setChildMean} sd={childSD} setSD={setChildSD}/>
         </Col>
-        <Col>
+        <Col xl={4} md={12} style={{padding: 10}}>
           <p>Set the Correlation</p>
           <InputSlider value={correlation} min={-1} max={1} step={0.1} onChange={(value) => setCorrelation(value)}/>
           <p style={{ margin: "15px" }}>Covariance</p>

--- a/src/components/LeastSquares/LeastSquaresSimulation.js
+++ b/src/components/LeastSquares/LeastSquaresSimulation.js
@@ -60,11 +60,11 @@ export default function LeastSquaresSimulation() {
 
   return (
     <div>
-      <Row>
-        <Col>
+      <Row style={{marginLeft: -100, marginRight: 0}}>
+        <Col xs="auto">
           <LeastSquaresChart points={points} linePoints={linePoints} setSquareAreas={setSquareAreas}/>
         </Col>
-        <Col xl="4" style={{paddingTop: "100px", width: "40%"}}>
+        <Col xs={{size: 3, offset: 3}} md={{size: 3, offset: 0}} style={{paddingTop: "100px"}}>
           <NewPointsInput generatePoints={generatePoints}/>
           <br/>
           {(stage === 2) && <p>Guess a Slope and Y-Intercept to fit the points</p>}

--- a/src/components/OmittedVariableBias/OVBSimulation.js
+++ b/src/components/OmittedVariableBias/OVBSimulation.js
@@ -127,7 +127,7 @@ export default function OVBSimulation() {
         <p className="Center">Choose Population Parameters:</p>
       </Row>
       <br/>
-      <Row>
+      <Row lg={2} sm={1}>
         <Col style={{margin: "auto"}}>
           <CoefficientInput beta={beta} setBeta={setBeta} delta={delta} setDelta={setDelta}/>
         </Col>

--- a/src/components/OmittedVariableBias/OVBSimulation.js
+++ b/src/components/OmittedVariableBias/OVBSimulation.js
@@ -128,11 +128,11 @@ export default function OVBSimulation() {
       </Row>
       <br/>
       <Row lg={2} sm={1}>
-        <Col style={{margin: "auto"}}>
+        <Col style={{margin: "auto", padding: 10}}>
           <CoefficientInput beta={beta} setBeta={setBeta} delta={delta} setDelta={setDelta}/>
         </Col>
         <Col>
-          <p>Set the Correlation between Study Hours and Sleep Hours:</p>
+          <div style={{padding: 10}}>Set the Correlation between Study Hours and Sleep Hours:</div>
           <InputSlider value={correlation} min={-0.99} max={0.99} step={.01} onChange={(value) => adjustCorrelation(value)}/>
           <br/>
           <InputGroup style={{width: "fit-content", margin: "auto"}}>
@@ -148,11 +148,12 @@ export default function OVBSimulation() {
           <Button color='primary' onClick={() => generateSeries()}>Generate!</Button>
         </Col>
       </Row>
+      <br/>
       {
         (stage >= 2) &&
         <div>
           <Row>
-            <Col>
+            <Col lg={{size: 12, offset: 0}} xl={{size: 8, offset: 2}}>
               <OmittedVariableChart
                 dataPoints={allData.points}
                 naiveLine={allData.naiveLine}

--- a/src/components/PopBar.js
+++ b/src/components/PopBar.js
@@ -8,8 +8,8 @@
     setPop  - callback
 */
 import React, { useState } from 'react';
-import { Button} from 'reactstrap';
 import PropTypes from 'prop-types';
+import SelectorButtonGroup from './SelectorButtonGroup';
 
 
 export default function PopBar({ sim, setPop }) {
@@ -27,16 +27,10 @@ export default function PopBar({ sim, setPop }) {
     setSelected(mode);
   }
 
-  const sections = modes.map((mode)=>
-    <Button key={mode} active={selected === mode} onClick={() => onClick(mode)}>
-      {mode}
-    </Button>
-  );
-
   return (
     <div className="buttonGroup">
       <p>Pick a Population Distribution: </p>
-      {sections}
+      <SelectorButtonGroup options={modes} select={onClick} selected={selected}/>
     </div>
   );
 }


### PR DESCRIPTION
I've learned more about how to have responsive column widths based on screen size. This PR includes spacing fixes for Joint Distributions, Least Squares, Omitted Variable Bias, and Confidence Intervals. All inputs should now be accessible at all screen sizes.

I also added a bit of styling to the `PopBar` buttons to make them "pop" out a bit more...

closes #36, closes #41 