### PR TITLE
PropTypes Review

### DIFF
--- a/src/components/CentralLimitTheorem/CLTSimulation.js
+++ b/src/components/CentralLimitTheorem/CLTSimulation.js
@@ -32,7 +32,7 @@ const resampleSize = {
   "Mystery": 0
 }
 
-export default function CLTSimulation({ popType, mainSampleSize }) {
+export default function CLTSimulation({ popShape, mainSampleSize }) {
   const [sampleMeans, setSampleMeans] = useState([]);
   const [sampled, setSampled] = useState([]);
   const [sampleSize, setSampleSize] = useState(mainSampleSize);
@@ -46,17 +46,17 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
     setPopArray([]);
     setSampled([]);
     setSampleMeans([]);
-  }, [popType]);
+  }, [popShape]);
 
   // Highcharts rendering is buggy - this second useEffect takes a second but allows the data to be reset completely before being generated again
   useEffect(() => {
     if (popArray.length === 0) {
-      const newPop = dataFromDistribution(popType, mainSampleSize);
+      const newPop = dataFromDistribution(popShape, mainSampleSize);
       setPopArray(newPop);
       const newMean = populationMean(newPop);
       setPopMean(newMean);
     }
-  }, [popArray, popType, mainSampleSize]);
+  }, [popArray, popShape, mainSampleSize]);
 
   const addSampleMeans = (means) => {
     if (!means) {  // calling addSampleMeans with no arguments clears the data
@@ -79,7 +79,7 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
   return (
     <Collapsable>
       <div>
-        <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} popType={popType}/>
+        <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} popShape={popShape}/>
         <Button color="success" onClick={() => setStage(2)}>Continue</Button>
         {(stage >= 2) &&
           <div>
@@ -100,12 +100,12 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
                 </Button>
                 <SampleMeanChart  // TODO: update this
                   numberResamples={numberResamples}
-                  resampleSize={resampleSize[popType]}
+                  resampleSize={resampleSize[popShape]}
                   mean={popMean}
                   sd={std(xvalue)}
                   normalized={standardNormal}
                   sampleSize={sampleSize}
-                  type={popType}
+                  type={popShape}
                   normal={standardNormal}
                   sampleMeans={sampleMeans}
                 />
@@ -136,6 +136,6 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
 }
 
 CLTSimulation.propTypes = {
-  popType: popShapeType.isRequired,
+  popShape: popShapeType.isRequired,
   mainSampleSize: PropTypes.number.isRequired,
 }

--- a/src/components/CentralLimitTheorem/CLTSimulation.js
+++ b/src/components/CentralLimitTheorem/CLTSimulation.js
@@ -59,8 +59,12 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
   }, [popArray, popType, mainSampleSize]);
 
   const addSampleMeans = (means) => {
-    const newSampleMeans = [...sampleMeans, ...means];
-    setSampleMeans(newSampleMeans);
+    if (!means) {  // calling addSampleMeans with no arguments clears the data
+      setSampleMeans([])
+    } else {
+      const newSampleMeans = [...sampleMeans, ...means];
+      setSampleMeans(newSampleMeans);
+    }
   }
 
   const handleClick = (size) => {
@@ -118,7 +122,6 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
                 <br/>
                 <SampleMeansSimulator
                   setSampleSize={setSampleSize}
-                  clear={() => setSampleMeans([])}
                   population={popArray}
                   addSamples={addSampleMeans}
                 />

--- a/src/components/CentralLimitTheorem/CLTSimulation.js
+++ b/src/components/CentralLimitTheorem/CLTSimulation.js
@@ -2,10 +2,6 @@
 
   Displays one of the CLT simulations
 
-  props:
-    popType        - string
-    mainSampleSize - int
-
 */
 import React, { useState, useEffect } from 'react';
 import Collapsable from '../Collapsable.js';
@@ -19,6 +15,7 @@ import SampleSizeInput from '../SampleSizeInput.js';
 import SampleMeansTable from './SampleMeansTable.js';
 import _ from "lodash";
 import PropTypes from 'prop-types';
+import { popShapeType } from '../../lib/types.js';
 
 const numberResamples = {
   "Normal": 0,
@@ -76,8 +73,8 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
   const xvalue = sampled.length === 0 ? [0] : sampled.map((s) => s[0]);  // provide a placeholder value until 'sampled' is updated
 
   return (
-    <div>
-      <Collapsable>
+    <Collapsable>
+      <div>
         <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} popType={popType}/>
         <Button color="success" onClick={() => setStage(2)}>Continue</Button>
         {(stage >= 2) &&
@@ -129,14 +126,13 @@ export default function CLTSimulation({ popType, mainSampleSize }) {
             </Row>
           </div>
         }
-      </Collapsable>
-    </div>
+
+      </div>
+    </Collapsable>
   );
 }
+
 CLTSimulation.propTypes = {
-
-  popType : PropTypes.string,
-  mainSampleSize : PropTypes.number,
-
-
+  popType: popShapeType.isRequired,
+  mainSampleSize: PropTypes.number.isRequired,
 }

--- a/src/components/CentralLimitTheorem/CentralLimitTheorem.js
+++ b/src/components/CentralLimitTheorem/CentralLimitTheorem.js
@@ -2,9 +2,6 @@
 
   Displays the description for the CLT simulation, a menu bar to choose the different variations, and the simulation component itself
 
-  props:
-    none
-
 */
 import React, { useState } from 'react';
 import PopBar from '../PopBar.js';

--- a/src/components/CentralLimitTheorem/CentralLimitTheorem.js
+++ b/src/components/CentralLimitTheorem/CentralLimitTheorem.js
@@ -11,7 +11,7 @@ import CLTSimulation from "./CLTSimulation.js";
 const SAMPLE_SIZE = 2000;
 
 export default function CentralLimitTheorem() {
-  const [popType, setPopType] = useState("");
+  const [popShape, setPopType] = useState("");
 
   return (
     <div className="MainContainer">
@@ -20,7 +20,7 @@ export default function CentralLimitTheorem() {
         This simulation demonstrates the shape of the sampling distribution of the sample mean. Suppose I draw a large number of samples, each of size 𝑛, from some population. For each sample, I calculate a sample mean 𝑥̅. I now plot a histogram of those sample means. For a sufficiently large sample size, the shape of that histogram will look like a beautiful bell-shaped curve, no matter what shape the underlying population had.
       </Alert>
       <PopBar sim="CLT" setPop={setPopType}/>
-      {popType && <CLTSimulation popType={popType} mainSampleSize={SAMPLE_SIZE}/>}
+      {popShape && <CLTSimulation popShape={popShape} mainSampleSize={SAMPLE_SIZE}/>}
     </div>
   );
 }

--- a/src/components/CentralLimitTheorem/SampleMeansSimulator.js
+++ b/src/components/CentralLimitTheorem/SampleMeansSimulator.js
@@ -8,7 +8,7 @@ import {Button, Input } from 'reactstrap';
 import { mean } from "mathjs";
 import _ from "lodash";
 import PropTypes from 'prop-types';
-import { popArrayType } from "../../lib/types";
+import { popArrayType } from "../../lib/types.js";
 
 export default function SampleMeansSimulator({ setSampleSize, clear, population, addSamples }) {
   const [numberResamples, setNumberResamples] = useState(0);

--- a/src/components/CentralLimitTheorem/SampleMeansSimulator.js
+++ b/src/components/CentralLimitTheorem/SampleMeansSimulator.js
@@ -2,18 +2,13 @@
 
   Displays inputs to allow the user to run a large number of resamples
 
-  props:
-    setSampleSize - callback
-    clear         - callback
-    population    - array
-    addSamples    - callback
-
 */
 import React, { useState } from "react";
 import {Button, Input } from 'reactstrap';
 import { mean } from "mathjs";
 import _ from "lodash";
 import PropTypes from 'prop-types';
+import { popArrayType } from "../../lib/types";
 
 export default function SampleMeansSimulator({ setSampleSize, clear, population, addSamples }) {
   const [numberResamples, setNumberResamples] = useState(0);
@@ -27,7 +22,7 @@ export default function SampleMeansSimulator({ setSampleSize, clear, population,
   const resample = () => {
     const samplePop = _.sampleSize(population, resampleSize);
     const sampleMean = mean(samplePop.map((s) => s[0]));
-    return [resampleSize, sampleMean];
+    return [+resampleSize, sampleMean];
   }
 
   const runSim = () => {
@@ -69,8 +64,8 @@ export default function SampleMeansSimulator({ setSampleSize, clear, population,
 }
 
 SampleMeansSimulator.propTypes = {
-  setSampleSize : PropTypes.func,
-  clear : PropTypes.func,
-  population: PropTypes.array,
-  addSamples:  PropTypes.func,
+  setSampleSize: PropTypes.func.isRequired,
+  clear: PropTypes.func.isRequired,
+  population: popArrayType.isRequired,
+  addSamples: PropTypes.func.isRequired,
 }

--- a/src/components/CentralLimitTheorem/SampleMeansSimulator.js
+++ b/src/components/CentralLimitTheorem/SampleMeansSimulator.js
@@ -10,7 +10,7 @@ import _ from "lodash";
 import PropTypes from 'prop-types';
 import { popArrayType } from "../../lib/types.js";
 
-export default function SampleMeansSimulator({ setSampleSize, clear, population, addSamples }) {
+export default function SampleMeansSimulator({ setSampleSize, population, addSamples }) {
   const [numberResamples, setNumberResamples] = useState(0);
   const [resampleSize, setResampleSize] = useState(0);
 
@@ -58,14 +58,13 @@ export default function SampleMeansSimulator({ setSampleSize, clear, population,
       <Button onClick={() => runSim()} disabled={(resampleSize < 1) || (resampleSize > population.length) || (numberResamples < 1)}>
         Run
       </Button>
-      <Button onClick={() => clear()}>Clear</Button>
+      <Button onClick={() => addSamples()}>Clear</Button>
     </div>
   );
 }
 
 SampleMeansSimulator.propTypes = {
   setSampleSize: PropTypes.func.isRequired,
-  clear: PropTypes.func.isRequired,
   population: popArrayType.isRequired,
   addSamples: PropTypes.func.isRequired,
 }

--- a/src/components/CentralLimitTheorem/SampleMeansTable.js
+++ b/src/components/CentralLimitTheorem/SampleMeansTable.js
@@ -33,6 +33,7 @@ export default function SampleMeansTable({ sampleMeans }) {
   </Table>
   );
 }
+
 SampleMeansTable.propTypes = {
   sampleMeans: popArrayType.isRequired,
 }

--- a/src/components/CentralLimitTheorem/SampleMeansTable.js
+++ b/src/components/CentralLimitTheorem/SampleMeansTable.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Table } from 'reactstrap';
 import { round } from "mathjs";
-import { sampleMeansType } from '../../lib/types';
+import { sampleMeansType } from '../../lib/types.js';
 
 export default function SampleMeansTable({ sampleMeans }) {
   const tableBody = sampleMeans.map((mean, index) =>

--- a/src/components/CentralLimitTheorem/SampleMeansTable.js
+++ b/src/components/CentralLimitTheorem/SampleMeansTable.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Table } from 'reactstrap';
 import { round } from "mathjs";
-import { sampleMeansType } from '../../lib/types.js';
+import { popArrayType } from '../../lib/types.js';
 
 export default function SampleMeansTable({ sampleMeans }) {
   const tableBody = sampleMeans.map((mean, index) =>
@@ -34,5 +34,5 @@ export default function SampleMeansTable({ sampleMeans }) {
   );
 }
 SampleMeansTable.propTypes = {
-  sampleMeans: sampleMeansType.isRequired,
+  sampleMeans: popArrayType.isRequired,
 }

--- a/src/components/CentralLimitTheorem/SampleMeansTable.js
+++ b/src/components/CentralLimitTheorem/SampleMeansTable.js
@@ -2,15 +2,12 @@
 
   Displays a table of sample means
 
-  props:
-    sampleMeans - array
-
 */
 
 import React from 'react';
 import { Table } from 'reactstrap';
 import { round } from "mathjs";
-import PropTypes from 'prop-types';
+import { sampleMeansType } from '../../lib/types';
 
 export default function SampleMeansTable({ sampleMeans }) {
   const tableBody = sampleMeans.map((mean, index) =>
@@ -37,7 +34,5 @@ export default function SampleMeansTable({ sampleMeans }) {
   );
 }
 SampleMeansTable.propTypes = {
-
-  sampleMeans : PropTypes.array,
-
+  sampleMeans: sampleMeansType.isRequired,
 }

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -67,10 +67,10 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
         </Row>
         <Row>
           <Col lg={2} md={12}>
-            <PopTable
+            <PopTable  // TODO: fix PopTable
               samples={sampled}
               popArray={popArray}
-              popType={popType}
+              popShape={popShape}
             />
           </Col>
           <Col lg={10}>

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -30,8 +30,8 @@ const texts = {
   Mystery: ['the height', 'Alien Females from planet Stata', "reported a height of", " inches."],
 }
 
-export default function ChartContainer({ popArray, popMean, sampled, sampleMean, popType }) {
-  const { xmaxval, xminval, ymaxval, title, xLabel } = values[popType];
+export default function ChartContainer({ popArray, popMean, sampled, sampleMean, popShape }) {
+  const { xmaxval, xminval, ymaxval, title, xLabel } = values[popShape];
 
   const series = [
     {
@@ -61,8 +61,8 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
       <Container fluid style={{marginBottom: "2vh"}}>
         <Row>
           <Alert color="secondary" className="Center">
-            {popType !== "Uniform" && <p>We queried the {texts[popType][0]} of {popArray.length} {texts[popType][1]} and plotted the results on the following chart.</p>}
-            {popType === "Uniform" && <p>Behavioral economists studying loss aversion design a lottery among 2000 participants where each amount between -10 and +10 is equally likely.  We plotted the winnings and losses below.</p>}
+            {popShape !== "Uniform" && <p>We queried the {texts[popShape][0]} of {popArray.length} {texts[popShape][1]} and plotted the results on the following chart.</p>}
+            {popShape === "Uniform" && <p>Behavioral economists studying loss aversion design a lottery among 2000 participants where each amount between -10 and +10 is equally likely.  We plotted the winnings and losses below.</p>}
           </Alert>
         </Row>
           <Row >
@@ -70,7 +70,7 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
               <PopTable  // TODO: fix PopTable
                 samples={sampled}
                 popArray={popArray}
-                popType={popType}
+                popShape={popShape}
               />
             </Col>
             <Col lg="8">
@@ -94,5 +94,5 @@ ChartContainer.propTypes = {
   popMean: PropTypes.number.isRequired,
   sampled: popArrayType.isRequired,
   sampleMean: PropTypes.number,
-  popType: popShapeType.isRequired,
+  popShape: popShapeType.isRequired,
 }

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -4,14 +4,7 @@
 
   Used by Law of Large Numbers and Central Limit Theorem
 
-  props:
-    popArray   - array
-    popMean    - float
-    sampled    - array
-    popType    - string
-    sampleSize - int
 */
-
 import React from 'react';
 import '../styles/dark-unica.css';
 import DotPlot from './DotPlot';
@@ -19,6 +12,7 @@ import { Alert, Container, Col, Row } from 'reactstrap';
 import PopTable from './PopTable.js'
 import _ from "lodash";
 import PropTypes from 'prop-types';
+import { popArrayType, popShapeType } from '../lib/types';
 
 const values = {
   Normal: { xmaxval: 74, xminval: 56, ymaxval: 40, title: "Milk Production", xLabel: "Gallons" },
@@ -73,7 +67,7 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
         </Row>
           <Row >
             <Col lg="2">
-              <PopTable
+              <PopTable  // TODO: fix PopTable
                 samples={sampled}
                 popArray={popArray}
                 popType={popType}
@@ -96,11 +90,9 @@ export default function ChartContainer({ popArray, popMean, sampled, sampleMean,
 }
 
 ChartContainer.propTypes = {
-
-  popArray : PropTypes.array ,
-  popMean : PropTypes.number,
-  sampled : PropTypes.array,
-  sampleMean : PropTypes.number,
-  popType : PropTypes.string,
-
+  popArray: popArrayType.isRequired,
+  popMean: PropTypes.number.isRequired,
+  sampled: popArrayType.isRequired,
+  sampleMean: PropTypes.number,
+  popType: popShapeType.isRequired,
 }

--- a/src/components/Collapsable.js
+++ b/src/components/Collapsable.js
@@ -2,9 +2,6 @@
 
   Uses the Collapse element to create a variable-size div for its contents
 
-  props:
-    children - react element
-
 */
 import React from 'react';
 import Collapse from 'react-collapse';
@@ -37,5 +34,5 @@ export default function Collapsable({ children }) {
 );
 }
 Collapsable.propTypes = {
-  children : PropTypes.element,
+  children: PropTypes.element.isRequired,
 }

--- a/src/components/Collapsable.js
+++ b/src/components/Collapsable.js
@@ -15,11 +15,11 @@ export default function Collapsable({ children }) {
     <div>
       <Collapse
         style={{
-            margin: "auto",
-            width: "100%",
-            textAlign: "center",
-            backgroundColor: "rgba(255,255,255,0.4)",
-            marginBottom: '1em'
+          margin: "auto",
+          width: "100%",
+          textAlign: "center",
+          backgroundColor: "rgba(255,255,255,0.4)",
+          marginBottom: '1em'
         }}
         isOpened
         springConfig={{ ...presets['gentle'] }}
@@ -31,8 +31,9 @@ export default function Collapsable({ children }) {
         </div>
       </Collapse>
     </div>
-);
+  );
 }
+
 Collapsable.propTypes = {
   children: PropTypes.element.isRequired,
 }

--- a/src/components/ConfidenceIntervals/CISimulation.js
+++ b/src/components/ConfidenceIntervals/CISimulation.js
@@ -104,8 +104,8 @@ export default function CISimulation({ popShape, populationSize }) {
           <PopulationChart
             popArray={popArray}
             popMean={populationMean(popArray)}
-            sampled={displaySample}  // most recent sample data
-            popType={popType}
+            sampled={selected ? selected.data : []}  // most recent sample data
+            popShape={popShape}
           />
           <p>Try drawing some samples and calculating means</p>
           <SampleSizeInput maxSize={popArray.length} handleClick={generateSamples}/>
@@ -114,7 +114,7 @@ export default function CISimulation({ popShape, populationSize }) {
           <ConfidenceIntervalsChart
             confidenceLevel={confLevel}
             samples={samples}
-            popType={popType}
+            popShape={popShape}
             popMean={_.round(populationMean(popArray))}
             selected={selected}
             setSelected={setSelected}
@@ -126,7 +126,6 @@ export default function CISimulation({ popShape, populationSize }) {
           <ManySamplesInput
             population={popArray}
             addSamples={generateSamples}
-            clear={clear}
           />
         </Col>
         <Col lg={12} xl={7}>

--- a/src/components/ConfidenceIntervals/CISimulation.js
+++ b/src/components/ConfidenceIntervals/CISimulation.js
@@ -6,14 +6,14 @@ import ConfidenceIntervalsChart from "./ConfidenceIntervalsChart.js";
 import ManySamplesInput from "./ManySamplesInput.js";
 import SamplesTable from "./SamplesTable.js";
 import { dataFromDistribution, populationMean } from "../../lib/stats-utils.js";
-import { Row, Col, Alert, Button } from "reactstrap";
+import { Row, Col, Alert } from "reactstrap";
 import PopulationChart from "./PopulationChart.js";
 import _ from "lodash";
 import { std } from "mathjs";
 import { jStat } from "jstat";
 import PropTypes from 'prop-types';
 import Highcharts from "highcharts";
-
+import { popShapeType } from "../../lib/types.js";
 
 export default function CISimulation({ popType, populationSize }) {
   const [distType, setDistType] = useState("Z");  // can be 'Z' or 'T'
@@ -52,34 +52,35 @@ export default function CISimulation({ popType, populationSize }) {
 
   const generateSamples = (size, replications=1) => {
     unselect();
-    const sampleObjects = [];
-    for (let i = 0; i < replications; i++) {
-      const sample = _.sampleSize(popArray, size);
-      const mean = _.round(populationMean(sample), 2);
-      const popMean = _.round(populationMean(popArray), 2);
-      const standardDev = std(((distType === "Z") ? popArray : sample).map((s) => s[0]));
-      const ciFunction = (distType === "Z") ? jStat.normalci : jStat.tci;
-      const [lowerConf, upperConf] = ciFunction(mean, 1 - (confLevel / 100), standardDev, size);
-      const sampleObject = {
-        data: sample,
-        size: +size,
-        mean: mean,
-        lowerConf: _.round(lowerConf, 2),
-        upperConf: _.round(upperConf, 2),
-        confidenceLevel: confLevel,
-        distribution: distType,
-        label: (popMean >= _.round(lowerConf, 2)) && (popMean <= _.round(upperConf, 2)),
+    if (!size) {  // calling generateSamples with no arguments clears the data
+      setSamples([]);
+      setSelected();
+    } else {
+      const sampleObjects = [];
+      for (let i = 0; i < replications; i++) {
+        const sample = _.sampleSize(popArray, size);
+        const mean = _.round(populationMean(sample), 2);
+        const popMean = _.round(populationMean(popArray), 2);
+        const standardDev = std(((distType === "Z") ? popArray : sample).map((s) => s[0]));
+        const ciFunction = (distType === "Z") ? jStat.normalci : jStat.tci;
+        const [lowerConf, upperConf] = ciFunction(mean, 1 - (confLevel / 100), standardDev, size);
+        const sampleObject = {
+          data: sample,
+          size: +size,
+          mean: mean,
+          lowerConf: _.round(lowerConf, 2),
+          upperConf: _.round(upperConf, 2),
+          confidenceLevel: confLevel,
+          distribution: distType,
+          label: (popMean >= _.round(lowerConf, 2)) && (popMean <= _.round(upperConf, 2)),
+        }
+        sampleObjects.push(sampleObject);
       }
-      sampleObjects.push(sampleObject);
+      const newSamples = [...samples, ...sampleObjects];
+      const indexedSamples = newSamples.map((sample, index) => ({...sample, id: index + 1}))
+      setSamples(indexedSamples);
+      setSelected(indexedSamples[indexedSamples.length - 1]);
     }
-    const newSamples = [...samples, ...sampleObjects];
-    const indexedSamples = newSamples.map((sample, index) => ({...sample, id: index + 1}))
-    setSamples(indexedSamples);
-  }
-
-  const clear = () => {
-    setSamples([]);
-    setSelected();
   }
 
   const selectPoint = (point) => {
@@ -87,69 +88,68 @@ export default function CISimulation({ popType, populationSize }) {
     unselect();
   }
 
-  const displaySample = (selected && selected.data) || ((samples.length > 0) ? samples[samples.length - 1].data : []);
-
   return (
     <Collapsable>
-      <Row>
-        <ConfidenceInputs
-          distType={distType}
-          setDistType={setDistType}
-          confLevel={confLevel}
-          setConfLevel={setConfLevel}
-        />
-      </Row>
-      <br/>
-      <Row>
-        <Col>
-          <PopulationChart
-            popArray={popArray}
-            popMean={populationMean(popArray)}
-            sampled={displaySample}  // most recent sample data
-            popType={popType}
+      <div>
+        <Row>
+          <ConfidenceInputs
+            distType={distType}
+            setDistType={setDistType}
+            confLevel={confLevel}
+            setConfLevel={setConfLevel}
           />
-          <p>Try drawing some samples and calculating means</p>
-          <SampleSizeInput maxSize={popArray.length} handleClick={generateSamples}/>
-        </Col>
-        <Col>
-          <ConfidenceIntervalsChart
-            confidenceLevel={confLevel}
-            samples={samples}
-            popType={popType}
-            popMean={_.round(populationMean(popArray))}
-            selected={selected}
-            setSelected={setSelected}
-          />
-        </Col>
-      </Row>
-      <Row>
-        <Col>
-          <ManySamplesInput
-            population={popArray}
-            addSamples={generateSamples}
-            clear={clear}
-          />
-        </Col>
-        <Col>
-          <SamplesTable samples={samples} setSelected={selectPoint}/>
-        </Col>
-      </Row>
-      <br/>
-      <Row lg="12">
-        {
-          (samples.length > 0) &&
-          <Alert color="info" style={{margin:'auto'}}>
-            {samples.filter(({ label }) => !label).length} intervals did not contain the population mean
-            <br/>
-            {samples.filter(({ label }) => label).length}, or {_.round(100 * samples.filter(({ label }) => label).length / samples.length, 2)}%, did
-          </Alert>
-        }
-      </Row>
+        </Row>
+        <br/>
+        <Row>
+          <Col>
+            <PopulationChart
+              popArray={popArray}
+              popMean={populationMean(popArray)}
+              sampled={selected ? selected.data : []}
+              popType={popType}
+            />
+            <p>Try drawing some samples and calculating means</p>
+            <SampleSizeInput maxSize={popArray.length} handleClick={generateSamples}/>
+          </Col>
+          <Col>
+            <ConfidenceIntervalsChart
+              confidenceLevel={confLevel}
+              samples={samples}
+              popType={popType}
+              popMean={_.round(populationMean(popArray), 2)}
+              selected={selected}
+              setSelected={setSelected}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <ManySamplesInput
+              population={popArray}
+              addSamples={generateSamples}
+            />
+          </Col>
+          <Col>
+            <SamplesTable samples={samples} setSelected={selectPoint}/>
+          </Col>
+        </Row>
+        <br/>
+        <Row lg="12">
+          {
+            (samples.length > 0) &&
+            <Alert color="info" style={{margin:'auto'}}>
+              {samples.filter(({ label }) => !label).length} intervals did not contain the population mean
+              <br/>
+              {samples.filter(({ label }) => label).length}, or {_.round(100 * samples.filter(({ label }) => label).length / samples.length, 2)}%, did
+            </Alert>
+          }
+        </Row>
+      </div>
     </Collapsable>
   );
 }
-CISimulation.propTypes = {
 
-  popType : PropTypes.string,
-  populationSize : PropTypes.number,
+CISimulation.propTypes = {
+  popType: popShapeType.isRequired,
+  populationSize: PropTypes.number.isRequired,
 }

--- a/src/components/ConfidenceIntervals/CISimulation.js
+++ b/src/components/ConfidenceIntervals/CISimulation.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import Highcharts from "highcharts";
 import { popShapeType } from "../../lib/types.js";
 
-export default function CISimulation({ popType, populationSize }) {
+export default function CISimulation({ popShape, populationSize }) {
   const [distType, setDistType] = useState("Z");  // can be 'Z' or 'T'
   const [confLevel, setConfLevel] = useState(95);
   const [popArray, setPopArray] = useState([]);
@@ -25,16 +25,16 @@ export default function CISimulation({ popType, populationSize }) {
   useEffect(() => {
     setPopArray([]);
     setSamples([]);
-  }, [popType]);
+  }, [popShape]);
 
   // Highcharts rendering is buggy - this second useEffect takes a second but allows the data to be reset completely before being generated again
   useEffect(() => {
     if (popArray.length === 0) {
       // adjust params for uniform distribution to fit example
-      const newPop = dataFromDistribution(popType, populationSize, {low: 54, hi: 74});
+      const newPop = dataFromDistribution(popShape, populationSize, {low: 54, hi: 74});
       setPopArray(newPop);
     }
-  }, [popArray, popType, populationSize]);
+  }, [popArray, popShape, populationSize]);
 
   // this is a hack to get around what I believe is a bug in highcharts
   // where a point will sometimes turn gray when selected
@@ -106,7 +106,7 @@ export default function CISimulation({ popType, populationSize }) {
               popArray={popArray}
               popMean={populationMean(popArray)}
               sampled={selected ? selected.data : []}
-              popType={popType}
+              popShape={popShape}
             />
             <p>Try drawing some samples and calculating means</p>
             <SampleSizeInput maxSize={popArray.length} handleClick={generateSamples}/>
@@ -115,7 +115,7 @@ export default function CISimulation({ popType, populationSize }) {
             <ConfidenceIntervalsChart
               confidenceLevel={confLevel}
               samples={samples}
-              popType={popType}
+              popShape={popShape}
               popMean={_.round(populationMean(popArray), 2)}
               selected={selected}
               setSelected={setSelected}
@@ -150,6 +150,6 @@ export default function CISimulation({ popType, populationSize }) {
 }
 
 CISimulation.propTypes = {
-  popType: popShapeType.isRequired,
+  popShape: popShapeType.isRequired,
   populationSize: PropTypes.number.isRequired,
 }

--- a/src/components/ConfidenceIntervals/ConfidenceInputs.js
+++ b/src/components/ConfidenceIntervals/ConfidenceInputs.js
@@ -5,7 +5,6 @@ import SelectorButtonGroup from "../SelectorButtonGroup.js";
 import PropTypes from 'prop-types';
 
 export default function ConfidenceInputs({ distType, setDistType, confLevel, setConfLevel }) {
-
   return (
     <div>
       <Row className="Center">
@@ -39,9 +38,8 @@ export default function ConfidenceInputs({ distType, setDistType, confLevel, set
 }
 
 ConfidenceInputs.propTypes = {
-
-  distType : PropTypes.oneOf(['z','t']),
-  setDistType : PropTypes.func,
-  confLevel : PropTypes.number,
-  setConfLevel : PropTypes.func,
+  distType: PropTypes.oneOf(["Z","T"]).isRequired,
+  setDistType: PropTypes.func.isRequired,
+  confLevel: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  setConfLevel: PropTypes.func.isRequired,
 }

--- a/src/components/ConfidenceIntervals/ConfidenceInputs.js
+++ b/src/components/ConfidenceIntervals/ConfidenceInputs.js
@@ -3,6 +3,7 @@ import { Row, Col } from "reactstrap";
 import InputSlider from "../InputSlider.js";
 import SelectorButtonGroup from "../SelectorButtonGroup.js";
 import PropTypes from 'prop-types';
+import { stringOrNumberType } from "../../lib/types.js";
 
 export default function ConfidenceInputs({ distType, setDistType, confLevel, setConfLevel }) {
   return (
@@ -40,6 +41,6 @@ export default function ConfidenceInputs({ distType, setDistType, confLevel, set
 ConfidenceInputs.propTypes = {
   distType: PropTypes.oneOf(["Z","T"]).isRequired,
   setDistType: PropTypes.func.isRequired,
-  confLevel: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  confLevel: stringOrNumberType.isRequired,
   setConfLevel: PropTypes.func.isRequired,
 }

--- a/src/components/ConfidenceIntervals/ConfidenceIntervals.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervals.js
@@ -6,7 +6,7 @@ import CISimulation from './CISimulation.js';
 const SAMPLE_SIZE = 2000;
 
 export default function ConfidenceIntervals() {
-  const [popType, setPopType] = useState("");
+  const [popShape, setPopType] = useState("");
 
   return (
     <div className="MainContainer">
@@ -17,7 +17,7 @@ export default function ConfidenceIntervals() {
         This simulation demonstrates how confidence intervals provide an estimate for the location of the true population mean µ. In this exercise you will first choose 1) whether to assume that you know the true population standard deviation and 2) what confidence level to impose. Then, you will take random samples from the population, calculation a sample mean for each, and construct confidence intervals around those sample means. The proportion of confidence intervals that contain the true mean corresponds to the chosen confidence level!
       </Alert>
       <PopBar sim="CI" setPop={setPopType}/>
-      {popType && <CISimulation popType={popType} populationSize={SAMPLE_SIZE}/>}
+      {popShape && <CISimulation popShape={popShape} populationSize={SAMPLE_SIZE}/>}
     </div>
   );
 }

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
@@ -6,6 +6,7 @@ import _ from "lodash";
 import More from "highcharts/highcharts-more";
 import { max } from "mathjs";
 import PropTypes from 'prop-types';
+import { confidenceIntervalsSampleType, popShapeType } from "../../lib/types";
 
 More(Highcharts);
 
@@ -205,14 +206,12 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
     setChart(newChart);
   }, [confidenceLevel, samples, popType, popMean, setSelected]);
 
-  const sample = selected || samples[samples.length - 1];
-
   return (
     <div>
       {
-        sample ? (
-          <Alert color={sample.label ? "success" : "danger"} className="Center">
-            Sample number {sample.id} has a mean of {sample.mean.toFixed(2)}, with {confidenceLevel}% CI ({_.round(sample.lowerConf, 2)}, {_.round(sample.upperConf, 2)}). CI contains the population mean? {sample.label.toString()}
+        selected ? (
+          <Alert color={selected.label ? "success" : "danger"} className="Center">
+            Sample number {selected.id} has a mean of {selected.mean.toFixed(2)}, with {confidenceLevel}% CI ({_.round(selected.lowerConf, 2)}, {_.round(selected.upperConf, 2)}). CI contains the population mean? {selected.label.toString()}
           </Alert>
         ) : <div style={{height: 80}}/>
       }
@@ -221,11 +220,10 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
   );
 }
 ConfidenceIntervalsChart.propTypes = {
-
-  confidenceLevel : PropTypes.number,
-  samples : PropTypes.array ,
-  popType : PropTypes.string,
-  popMean : PropTypes.number,
-  selected : PropTypes.string,
-  setSelected : PropTypes.func,
+  confidenceLevel: PropTypes.number.isRequired,
+  samples: PropTypes.arrayOf(confidenceIntervalsSampleType).isRequired,
+  popType: popShapeType.isRequired,
+  popMean: PropTypes.number.isRequired,
+  selected: confidenceIntervalsSampleType,
+  setSelected: PropTypes.func.isRequired,
 }

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
@@ -17,11 +17,11 @@ const values = {
   "Chi-Squared": {xmaxval: 25, xminval: 0, title: "Money Spent on Lunch", xLabel: "Dollars"}
   }
 
-export default function ConfidenceIntervalsChart({ confidenceLevel, samples, popType, popMean, selected, setSelected }) {
+export default function ConfidenceIntervalsChart({ confidenceLevel, samples, popShape, popMean, selected, setSelected }) {
   const [chart, setChart] = useState({});
 
   useEffect(() => {
-    const { xmaxval, xminval, title, xLabel } = values[popType];
+    const { xmaxval, xminval, title, xLabel } = values[popShape];
 
     const sampleMeans = [];
     const containsMean = [];
@@ -204,7 +204,7 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
       ]
     }
     setChart(newChart);
-  }, [confidenceLevel, samples, popType, popMean, setSelected]);
+  }, [confidenceLevel, samples, popShape, popMean, setSelected]);
 
   return (
     <div>
@@ -222,7 +222,7 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
 ConfidenceIntervalsChart.propTypes = {
   confidenceLevel: PropTypes.number.isRequired,
   samples: PropTypes.arrayOf(confidenceIntervalsSampleType).isRequired,
-  popType: popShapeType.isRequired,
+  popShape: popShapeType.isRequired,
   popMean: PropTypes.number.isRequired,
   selected: confidenceIntervalsSampleType,
   setSelected: PropTypes.func.isRequired,

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
@@ -6,7 +6,7 @@ import _ from "lodash";
 import More from "highcharts/highcharts-more";
 import { max } from "mathjs";
 import PropTypes from 'prop-types';
-import { confidenceIntervalsSampleType, popShapeType } from "../../lib/types";
+import { confidenceIntervalsSampleType, popShapeType } from "../../lib/types.js";
 
 More(Highcharts);
 

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsChart.js
@@ -219,6 +219,7 @@ export default function ConfidenceIntervalsChart({ confidenceLevel, samples, pop
     </div>
   );
 }
+
 ConfidenceIntervalsChart.propTypes = {
   confidenceLevel: PropTypes.number.isRequired,
   samples: PropTypes.arrayOf(confidenceIntervalsSampleType).isRequired,

--- a/src/components/ConfidenceIntervals/ManySamplesInput.js
+++ b/src/components/ConfidenceIntervals/ManySamplesInput.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { Button, Input, Alert } from 'reactstrap';
 import PropTypes from 'prop-types';
+import { popArrayType } from "../../lib/types";
 
-export default function ManySamplesInput({ population, addSamples, clear }) {
+export default function ManySamplesInput({ population, addSamples }) {
   const [numberResamples, setNumberResamples] = useState(0);
   const [resampleSize, setResampleSize] = useState(0);
 
@@ -38,15 +39,12 @@ export default function ManySamplesInput({ population, addSamples, clear }) {
       >
         Run
       </Button>
-      <Button onClick={() => clear()}>Clear</Button>
+      <Button onClick={() => addSamples()}>Clear</Button>
     </div>
   );
 }
 
 ManySamplesInput.propTypes = {
-
-  population : PropTypes.array,
-  addSamples : PropTypes.func,
-  clear : PropTypes.func,
-
+  population: popArrayType.isRequired,
+  addSamples: PropTypes.func.isRequired,
 }

--- a/src/components/ConfidenceIntervals/ManySamplesInput.js
+++ b/src/components/ConfidenceIntervals/ManySamplesInput.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button, Input, Alert } from 'reactstrap';
 import PropTypes from 'prop-types';
-import { popArrayType } from "../../lib/types";
+import { popArrayType } from "../../lib/types.js";
 
 export default function ManySamplesInput({ population, addSamples }) {
   const [numberResamples, setNumberResamples] = useState(0);

--- a/src/components/ConfidenceIntervals/PopulationChart.js
+++ b/src/components/ConfidenceIntervals/PopulationChart.js
@@ -3,6 +3,7 @@ import DotPlot from "../DotPlot";
 import { Alert, Container } from "reactstrap";
 import _ from "lodash";
 import PropTypes from 'prop-types';
+import { popArrayType, popShapeType } from "../../lib/types";
 
 export default function PopulationChart({ popArray, popMean, sampled, popType }) {
 
@@ -48,13 +49,11 @@ export default function PopulationChart({ popArray, popMean, sampled, popType })
       />
   </Container>
   );
-
 }
 
 PopulationChart.propTypes = {
-
-  popArray : PropTypes.array,
-  popMean : PropTypes.number,
-  sampled : PropTypes.array,
-  distType :  PropTypes.oneOf(['z','t']),
+  popArray: popArrayType.isRequired,
+  popMean: PropTypes.number,
+  sampled: popArrayType.isRequired,
+  popType: popShapeType.isRequired
 }

--- a/src/components/ConfidenceIntervals/PopulationChart.js
+++ b/src/components/ConfidenceIntervals/PopulationChart.js
@@ -5,7 +5,7 @@ import _ from "lodash";
 import PropTypes from 'prop-types';
 import { popArrayType, popShapeType } from "../../lib/types";
 
-export default function PopulationChart({ popArray, popMean, sampled, popType }) {
+export default function PopulationChart({ popArray, popMean, sampled, popShape }) {
 
   const values = {
     Normal: { xmaxval: 74, xminval: 56, ymaxval: 40, title: "Milk Production", xLabel: "Gallons" },
@@ -21,7 +21,7 @@ export default function PopulationChart({ popArray, popMean, sampled, popType })
     "Chi-Squared": ["expenditure", "workers on lunch"]
   }
 
-  const { xmaxval, xminval, ymaxval, title, xLabel } = values[popType];
+  const { xmaxval, xminval, ymaxval, title, xLabel } = values[popShape];
 
   const series = [
     {
@@ -37,7 +37,7 @@ export default function PopulationChart({ popArray, popMean, sampled, popType })
   return (
     <Container fluid>
       <Alert color="secondary" className="Center">
-        We queried the {texts[popType][0]} of {popArray.length} {texts[popType][1]} and plotted the results on the following chart.
+        We queried the {texts[popShape][0]} of {popArray.length} {texts[popShape][1]} and plotted the results on the following chart.
       </Alert>
       <DotPlot
         series={series}
@@ -55,5 +55,5 @@ PopulationChart.propTypes = {
   popArray: popArrayType.isRequired,
   popMean: PropTypes.number,
   sampled: popArrayType.isRequired,
-  popType: popShapeType.isRequired
+  popShape: popShapeType.isRequired
 }

--- a/src/components/ConfidenceIntervals/PopulationChart.js
+++ b/src/components/ConfidenceIntervals/PopulationChart.js
@@ -3,7 +3,7 @@ import DotPlot from "../DotPlot";
 import { Alert, Container } from "reactstrap";
 import _ from "lodash";
 import PropTypes from 'prop-types';
-import { popArrayType, popShapeType } from "../../lib/types";
+import { popArrayType, popShapeType } from "../../lib/types.js";
 
 export default function PopulationChart({ popArray, popMean, sampled, popShape }) {
 

--- a/src/components/ConfidenceIntervals/SamplesTable.js
+++ b/src/components/ConfidenceIntervals/SamplesTable.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Table } from "reactstrap";
 import PropTypes from 'prop-types';
+import { confidenceIntervalsSampleType } from "../../lib/types";
 
 export default function SamplesTable({ samples, setSelected }) {
 
@@ -43,10 +44,8 @@ export default function SamplesTable({ samples, setSelected }) {
     </div>
   )
 }
+
 SamplesTable.propTypes = {
-
-  samples : PropTypes.array,
-  setSelected : PropTypes.func,
-
-
+  samples: PropTypes.arrayOf(confidenceIntervalsSampleType).isRequired,
+  setSelected: PropTypes.func.isRequired,
 }

--- a/src/components/ConfidenceIntervals/SamplesTable.js
+++ b/src/components/ConfidenceIntervals/SamplesTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "reactstrap";
 import PropTypes from 'prop-types';
-import { confidenceIntervalsSampleType } from "../../lib/types";
+import { confidenceIntervalsSampleType } from "../../lib/types.js";
 
 export default function SamplesTable({ samples, setSelected }) {
 

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -3,7 +3,7 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official'
 import Label from 'highcharts/modules/series-label';
 import PropTypes from 'prop-types';
-import { dotPlotSeriesType } from "../lib/types";
+import { highchartsSeriesType } from "../lib/types";
 
 Label(Highcharts);
 
@@ -68,7 +68,7 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel }) {
   return <HighchartsReact highcharts={Highcharts} options={chart}/>
 }
 DotPlot.propTypes = {
-  series: dotPlotSeriesType.isRequired,
+  series: highchartsSeriesType.isRequired,
   title: PropTypes.string,
   xMin: PropTypes.number,
   xMax: PropTypes.number,

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -3,6 +3,7 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official'
 import Label from 'highcharts/modules/series-label';
 import PropTypes from 'prop-types';
+import { dotPlotSeriesType } from "../lib/types";
 
 Label(Highcharts);
 
@@ -67,12 +68,11 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel }) {
   return <HighchartsReact highcharts={Highcharts} options={chart}/>
 }
 DotPlot.propTypes = {
-
-    series : PropTypes.object,
-    title  : PropTypes.object,
-    xMin  : PropTypes.number,
-    xMax  : PropTypes.number,
-    yMax : PropTypes.number,
-    xLabel : PropTypes.string,
-    yLabel : PropTypes.string,
+  series: dotPlotSeriesType.isRequired,
+  title: PropTypes.string,
+  xMin: PropTypes.number,
+  xMax: PropTypes.number,
+  yMax: PropTypes.number,
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string,
 }

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -67,6 +67,7 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel }) {
 
   return <HighchartsReact highcharts={Highcharts} options={chart}/>
 }
+
 DotPlot.propTypes = {
   series: highchartsSeriesType.isRequired,
   title: PropTypes.string,

--- a/src/components/HypothesisTesting/HTSimulation.js
+++ b/src/components/HypothesisTesting/HTSimulation.js
@@ -20,7 +20,7 @@ export default function HTSimulation() {
 
   return (
     <div className="MainContainer">
-      <TestInputs testType={testType} setTestType={setTestType} popType={pplShape} setPopType={setPplShape}/>
+      <TestInputs testType={testType} setTestType={setTestType} popShape={pplShape} setPopType={setPplShape}/>
       {(stage >= 2) &&
       <Container fluid>
         <Row>

--- a/src/components/HypothesisTesting/TestInputs.js
+++ b/src/components/HypothesisTesting/TestInputs.js
@@ -3,7 +3,7 @@ import SelectorButtonGroup from "../SelectorButtonGroup";
 import { Row } from "reactstrap";
 import PropTypes from "prop-types";
 
-export default function TestInputs({ testType, setTestType, popType, setPopType }) {
+export default function TestInputs({ testType, setTestType, popShape, setPopType }) {
 
   return (
     <div style={{ padding: 20 }}>
@@ -16,7 +16,7 @@ export default function TestInputs({ testType, setTestType, popType, setPopType 
       <Row style={{ padding: 10 }}>
         <div>
           <div style={{ padding: 10 }}>Choose a population distribution shape:</div>
-          <SelectorButtonGroup options={["Normal", "Uniform", "Mystery", "??Unknown??"]} select={setPopType} selected={popType}/>
+          <SelectorButtonGroup options={["Normal", "Uniform", "Mystery", "??Unknown??"]} select={setPopType} selected={popShape}/>
         </div>
       </Row>
     </div>
@@ -26,6 +26,6 @@ export default function TestInputs({ testType, setTestType, popType, setPopType 
 TestInputs.propTypes = {
   testType: PropTypes.string.isRequired,
   setTestType: PropTypes.func.isRequired,
-  popType: PropTypes.string.isRequired,
+  popShape: PropTypes.string.isRequired,
   setPopType: PropTypes.func.isRequired
 }

--- a/src/components/InputSlider.js
+++ b/src/components/InputSlider.js
@@ -30,6 +30,7 @@ export default function InputSlider({ value, min, max, step, onChange }) {
     </InputGroup>
   );
 }
+
 InputSlider.propTypes = {
   value: stringOrNumberType.isRequired,
   min: PropTypes.number.isRequired,

--- a/src/components/InputSlider.js
+++ b/src/components/InputSlider.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Input, InputGroup, InputGroupAddon } from "reactstrap";
 import PropTypes from 'prop-types';
+import { stringOrNumberType } from "../lib/types";
 
 export default function InputSlider({ value, min, max, step, onChange }) {
   return (
@@ -30,7 +31,7 @@ export default function InputSlider({ value, min, max, step, onChange }) {
   );
 }
 InputSlider.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  value: stringOrNumberType.isRequired,
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
   step: PropTypes.number.isRequired,

--- a/src/components/JointDistributions/JDCharts.js
+++ b/src/components/JointDistributions/JDCharts.js
@@ -8,7 +8,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { Row, Col } from 'reactstrap';
 import JointChart from "./JointChart.js";
 import { ResponsiveScatterPlotCanvas } from "@nivo/scatterplot";
-import { jointDistributionsDataType } from "../../lib/types.js";
+import { xyPointsType } from "../../lib/types.js";
 
 export default function JDCharts({ parentData, childData, jointData }) {
   // these functions synchronize the plots - all three corresponding data points increase in size on mouse over
@@ -81,7 +81,7 @@ export default function JDCharts({ parentData, childData, jointData }) {
 }
 
 JDCharts.propTypes = {
-  parentData: jointDistributionsDataType.isRequired,
-  childData: jointDistributionsDataType.isRequired,
-  jointData: jointDistributionsDataType.isRequired,
+  parentData: xyPointsType.isRequired,
+  childData: xyPointsType.isRequired,
+  jointData: xyPointsType.isRequired,
 }

--- a/src/components/JointDistributions/JDCharts.js
+++ b/src/components/JointDistributions/JDCharts.js
@@ -3,15 +3,12 @@
   A container component to hold the three charts for the Joint Distribution simulation
   Note that Nivo is used for these plots instead of HighCharts - easier to synchronize
 
-  props:
-    parentData, childData, jointData - array[Object{x, y}]
-
 */
 import React, { useState, useCallback, useMemo } from "react";
 import { Row, Col } from 'reactstrap';
 import JointChart from "./JointChart.js";
 import { ResponsiveScatterPlotCanvas } from "@nivo/scatterplot";
-import PropTypes from 'prop-types';
+import { jointDistributionsDataType } from "../../lib/types.js";
 
 export default function JDCharts({ parentData, childData, jointData }) {
   // these functions synchronize the plots - all three corresponding data points increase in size on mouse over
@@ -82,8 +79,9 @@ export default function JDCharts({ parentData, childData, jointData }) {
     </Row>
   )
 }
+
 JDCharts.propTypes = {
-  parentData: PropTypes.arrayOf(PropTypes.object),
-  childData: PropTypes.arrayOf(PropTypes.object),
-  jointData: PropTypes.arrayOf(PropTypes.object),
+  parentData: jointDistributionsDataType.isRequired,
+  childData: jointDistributionsDataType.isRequired,
+  jointData: jointDistributionsDataType.isRequired,
 }

--- a/src/components/JointDistributions/JDSimulation.js
+++ b/src/components/JointDistributions/JDSimulation.js
@@ -2,9 +2,6 @@
 
   Displays the Joint Distributions simulation
 
-  props:
-    none
-
 */
 import React, { useEffect, useState } from 'react';
 import MultivariateNormal from 'multivariate-normal';

--- a/src/components/JointDistributions/JointChart.js
+++ b/src/components/JointDistributions/JointChart.js
@@ -2,15 +2,12 @@
 
   Displays a Nivo scatterplot for the joint distribution data
 
-  props:
-    jointData     - array[Object{x, y}]
-    sharedOptions - object
-
 */
 import React from 'react';
 import { ResponsiveScatterPlot } from "@nivo/scatterplot";
 import { Col } from 'reactstrap';
 import PropTypes from 'prop-types';
+import { jointDistributionsDataType } from '../../lib/types';
 
 export default function JointChart({ jointData, sharedOptions, nodeId }) {
 
@@ -49,7 +46,9 @@ export default function JointChart({ jointData, sharedOptions, nodeId }) {
     </Col>
   );
 }
+
 JointChart.propTypes = {
-  sharedOptions: PropTypes.object,
-  jointData: PropTypes.arrayOf(PropTypes.object),
+  jointData: jointDistributionsDataType.isRequired,
+  sharedOptions: PropTypes.objectOf(PropTypes.any).isRequired,
+  nodeId: PropTypes.string,
 }

--- a/src/components/JointDistributions/JointChart.js
+++ b/src/components/JointDistributions/JointChart.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { ResponsiveScatterPlot } from "@nivo/scatterplot";
 import { Col } from 'reactstrap';
 import PropTypes from 'prop-types';
-import { jointDistributionsDataType } from '../../lib/types';
+import { xyPointsType } from '../../lib/types.js';
 
 export default function JointChart({ jointData, sharedOptions, nodeId }) {
 
@@ -48,7 +48,7 @@ export default function JointChart({ jointData, sharedOptions, nodeId }) {
 }
 
 JointChart.propTypes = {
-  jointData: jointDistributionsDataType.isRequired,
+  jointData: xyPointsType.isRequired,
   sharedOptions: PropTypes.objectOf(PropTypes.any).isRequired,
   nodeId: PropTypes.string,
 }

--- a/src/components/JointDistributions/JointDistributions.js
+++ b/src/components/JointDistributions/JointDistributions.js
@@ -2,9 +2,6 @@
 
   A container component that holds the description and simulation for Joint Distribution
 
-  props:
-    none
-
 */
 import React from 'react';
 import { Alert } from 'reactstrap';

--- a/src/components/JointDistributions/MeanSDInput.js
+++ b/src/components/JointDistributions/MeanSDInput.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import PropTypes from 'prop-types';
-import { stringOrNumberType } from '../../lib/types';
+import { stringOrNumberType } from '../../lib/types.js';
 
 export default function MeanSDInput({ title, mean, setMean, sd, setSD }){
   return (

--- a/src/components/JointDistributions/MeanSDInput.js
+++ b/src/components/JointDistributions/MeanSDInput.js
@@ -2,19 +2,12 @@
 
   Displays sliders for the user to adjust the mean and standard deviation
 
-  props:
-    title   - string
-    mean    - float
-    setMean - callback
-    sd      - float
-    setSD   - callback
-
 */
 import React from 'react';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import PropTypes from 'prop-types';
 
-export default function MeanSDInput({ title, mean, setMean, sd, setSD}){
+export default function MeanSDInput({ title, mean, setMean, sd, setSD }){
   return (
     <div>
       <p> Choose the Mean and Standard Deviation for {title} Height </p>

--- a/src/components/JointDistributions/MeanSDInput.js
+++ b/src/components/JointDistributions/MeanSDInput.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import PropTypes from 'prop-types';
+import { stringOrNumberType } from '../../lib/types';
 
 export default function MeanSDInput({ title, mean, setMean, sd, setSD }){
   return (
@@ -30,8 +31,8 @@ export default function MeanSDInput({ title, mean, setMean, sd, setSD }){
 
 MeanSDInput.propTypes = {
   title: PropTypes.string.isRequired,
-  mean: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  mean: stringOrNumberType.isRequired,
   setMean: PropTypes.func.isRequired,
-  sd: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  sd: stringOrNumberType.isRequired,
   setSD: PropTypes.func.isRequired,
 }

--- a/src/components/LawOfLargeNumbers/LLNSimulation.js
+++ b/src/components/LawOfLargeNumbers/LLNSimulation.js
@@ -2,10 +2,6 @@
 
   Displays one of the LLN simulations
 
-  props:
-    popType     - string
-    sampleSize  - int
-
 */
 import React, { useEffect, useState } from 'react';
 import Collapsable from '../Collapsable.js';
@@ -17,11 +13,12 @@ import { populationMean, dataFromDistribution } from "../../lib/stats-utils.js";
 import _ from "lodash";
 import { round } from "mathjs";
 import PropTypes from 'prop-types';
+import { popShapeType } from '../../lib/types.js';
 
 export default function LLNSimulation({ popType, sampleSize }) {
   const [sampled, setSampled] = useState([]);
   const [stage, setStage] = useState(1);
-  const [sampleMean, setSampleMean] = useState(0);
+  const [sampleMean, setSampleMean] = useState();
   const [popArray, setPopArray] = useState([]);
   const [popMean, setPopMean] = useState(0);
 
@@ -29,7 +26,7 @@ export default function LLNSimulation({ popType, sampleSize }) {
     setStage(1);
     setPopArray([]);
     setSampled([]);
-    setSampleMean(0);
+    setSampleMean();
   }, [popType]);
 
   // Highcharts rendering is buggy - this second useEffect takes a second but allows the data to be reset completely before being generated again
@@ -58,26 +55,29 @@ export default function LLNSimulation({ popType, sampleSize }) {
 
   return (
     <Collapsable>
-      <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} sampleMean={sampleMean} popType={popType}/>
-      <p>Try a few different sample sizes and compare sample mean to population mean</p>
-      <SampleSizeInput maxSize={popArray.length} handleClick={handleClick}/>
-      {(stage >= 2) &&
-        <div>
-          <Alert color="success" style={{ padding: 0, marginTop: '1em' }}>
-            Sample Mean: {_.round(sampleMean, 2) || ''}
-            <br/>
-            Difference of Means: {differenceOfMeans()}
-          </Alert>
-          <Alert color="info">
-            According to the law, the average of the results obtained from a large enough sample should be close to the total average of the population, and will tend to become closer the larger the sample is. Make sure to pick several samples, or see below for a simulation to see the law in action.
-          </Alert>
-          <SimulateSamples type={popType} popArray={popArray} popMean={_.round(popMean, 2)}/>
-        </div>
-      }
+      <div>
+        <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} sampleMean={sampleMean} popType={popType}/>
+        <p>Try a few different sample sizes and compare sample mean to population mean</p>
+        <SampleSizeInput maxSize={popArray.length} handleClick={handleClick}/>
+        {(stage >= 2) &&
+          <div>
+            <Alert color="success" style={{ padding: 0, marginTop: '1em' }}>
+              Sample Mean: {_.round(sampleMean, 2) || ''}
+              <br/>
+              Difference of Means: {differenceOfMeans()}
+            </Alert>
+            <Alert color="info">
+              According to the law, the average of the results obtained from a large enough sample should be close to the total average of the population, and will tend to become closer the larger the sample is. Make sure to pick several samples, or see below for a simulation to see the law in action.
+            </Alert>
+            <SimulateSamples type={popType} popArray={popArray} popMean={_.round(popMean, 2)}/>
+          </div>
+        }
+      </div>
     </Collapsable>
   );
 }
+
 LLNSimulation.propTypes =  {
-  popType : PropTypes.string ,
-  sampleSize : PropTypes.number,
+  popType: popShapeType.isRequired,
+  sampleSize: PropTypes.number.isRequired,
 }

--- a/src/components/LawOfLargeNumbers/LLNSimulation.js
+++ b/src/components/LawOfLargeNumbers/LLNSimulation.js
@@ -15,7 +15,7 @@ import { round } from "mathjs";
 import PropTypes from 'prop-types';
 import { popShapeType } from '../../lib/types.js';
 
-export default function LLNSimulation({ popType, sampleSize }) {
+export default function LLNSimulation({ popShape, sampleSize }) {
   const [sampled, setSampled] = useState([]);
   const [stage, setStage] = useState(1);
   const [sampleMean, setSampleMean] = useState();
@@ -27,17 +27,17 @@ export default function LLNSimulation({ popType, sampleSize }) {
     setPopArray([]);
     setSampled([]);
     setSampleMean();
-  }, [popType]);
+  }, [popShape]);
 
   // Highcharts rendering is buggy - this second useEffect takes a second but allows the data to be reset completely before being generated again
   useEffect(() => {
     if (popArray.length === 0) {
-      const newPop = dataFromDistribution(popType, sampleSize);
+      const newPop = dataFromDistribution(popShape, sampleSize);
       setPopArray(newPop);
       const newMean = populationMean(newPop);
       setPopMean(newMean);
     }
-  }, [popArray, popType, sampleSize]);
+  }, [popArray, popShape, sampleSize]);
 
   const handleClick = (size) => {
     const sample = _.sampleSize(popArray, size);
@@ -56,7 +56,7 @@ export default function LLNSimulation({ popType, sampleSize }) {
   return (
     <Collapsable>
       <div>
-        <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} sampleMean={sampleMean} popType={popType}/>
+        <ChartContainer popArray={popArray} popMean={popMean} sampled={sampled} sampleMean={sampleMean} popShape={popShape}/>
         <p>Try a few different sample sizes and compare sample mean to population mean</p>
         <SampleSizeInput maxSize={popArray.length} handleClick={handleClick}/>
         {(stage >= 2) &&
@@ -69,7 +69,7 @@ export default function LLNSimulation({ popType, sampleSize }) {
             <Alert color="info">
               According to the law, the average of the results obtained from a large enough sample should be close to the total average of the population, and will tend to become closer the larger the sample is. Make sure to pick several samples, or see below for a simulation to see the law in action.
             </Alert>
-            <SimulateSamples type={popType} popArray={popArray} popMean={_.round(popMean, 2)}/>
+            <SimulateSamples type={popShape} popArray={popArray} popMean={_.round(popMean, 2)}/>
           </div>
         }
       </div>
@@ -78,6 +78,6 @@ export default function LLNSimulation({ popType, sampleSize }) {
 }
 
 LLNSimulation.propTypes =  {
-  popType: popShapeType.isRequired,
+  popShape: popShapeType.isRequired,
   sampleSize: PropTypes.number.isRequired,
 }

--- a/src/components/LawOfLargeNumbers/LawOfLargeNumbers.js
+++ b/src/components/LawOfLargeNumbers/LawOfLargeNumbers.js
@@ -2,9 +2,6 @@
 
   Displays the description for the LLN simulation, a menu bar to choose the different variations, and the simulation component itself
 
-  props:
-    none
-
 */
 import React, { useState } from 'react';
 import PopBar from '../PopBar.js';

--- a/src/components/LawOfLargeNumbers/LawOfLargeNumbers.js
+++ b/src/components/LawOfLargeNumbers/LawOfLargeNumbers.js
@@ -11,7 +11,7 @@ import LLNSimulation from './LLNSimulation.js';
 const SAMPLE_SIZE = 2000;
 
 export default function LawOfLargeNumbers() {
-  const [popType, setPopType] = useState("");
+  const [popShape, setPopType] = useState("");
 
   return (
     <div className="MainContainer">
@@ -20,7 +20,7 @@ export default function LawOfLargeNumbers() {
         The Law of Large Numbers (LLN) is a statement about the relationship between a population and a random sample drawn from that population. Let 𝜇 denote the true mean of a variable when calculated using the entire population, let 𝜎 denote the true standard deviation of that variable when calculated using the entire population, let 𝑥̅ denote the mean calculated from a sample drawn from that population, and let 𝑠 denote the standard deviation calculated from that sample. We would like to use information from the sample to make conclusions about the population. The LLN is helpful in this endeavor, because it states that as the sample size gets larger, the sample mean approaches the true population mean. This simulation’s goal is to demonstrate this handy property.
       </Alert>
       <PopBar sim="LLN" setPop={setPopType}/>
-      {popType && <LLNSimulation popType={popType} sampleSize={SAMPLE_SIZE}/>}
+      {popShape && <LLNSimulation popShape={popShape} sampleSize={SAMPLE_SIZE}/>}
     </div>
   );
 }

--- a/src/components/LawOfLargeNumbers/SimulateSamples.js
+++ b/src/components/LawOfLargeNumbers/SimulateSamples.js
@@ -6,6 +6,7 @@ import { Collapse, Card, CardBody } from 'reactstrap';
 import '../../styles/dark-unica.css';
 import _ from "lodash";
 import PropTypes from 'prop-types';
+import { popArrayType, popShapeType } from '../../lib/types';
 
 export default function SimulateSamples({ type, popArray, popMean }) {
   const [sampled, setSampled] = useState([]);
@@ -94,6 +95,8 @@ export default function SimulateSamples({ type, popArray, popMean }) {
       setSampled(sampled => [...sampled, {y: avg}]);
       setMeanLine(meanLine => [...meanLine, {y: popMean}]);
     }, n);
+
+    return () => clearInterval(timer);
   }, []);  // eslint-disable-line
 
   return (
@@ -107,8 +110,7 @@ export default function SimulateSamples({ type, popArray, popMean }) {
   );
 }
 SimulateSamples.propTypes = {
-
-  type : PropTypes.string,
-  popArray : PropTypes.array,
-  popMean : PropTypes.number,
+  type: popShapeType.isRequired,
+  popArray: popArrayType.isRequired,
+  popMean: PropTypes.number.isRequired,
 }

--- a/src/components/LawOfLargeNumbers/SimulateSamples.js
+++ b/src/components/LawOfLargeNumbers/SimulateSamples.js
@@ -109,6 +109,7 @@ export default function SimulateSamples({ type, popArray, popMean }) {
     </Collapse>
   );
 }
+
 SimulateSamples.propTypes = {
   type: popShapeType.isRequired,
   popArray: popArrayType.isRequired,

--- a/src/components/LawOfLargeNumbers/SimulateSamples.js
+++ b/src/components/LawOfLargeNumbers/SimulateSamples.js
@@ -6,7 +6,7 @@ import { Collapse, Card, CardBody } from 'reactstrap';
 import '../../styles/dark-unica.css';
 import _ from "lodash";
 import PropTypes from 'prop-types';
-import { popArrayType, popShapeType } from '../../lib/types';
+import { popArrayType, popShapeType } from '../../lib/types.js';
 
 export default function SimulateSamples({ type, popArray, popMean }) {
   const [sampled, setSampled] = useState([]);

--- a/src/components/LeastSquares/LeastSquares.js
+++ b/src/components/LeastSquares/LeastSquares.js
@@ -2,9 +2,6 @@
 
   A container component that holds the description and simulation for Least Squares
 
-  props:
-    none
-
 */
 import React from "react";
 import LeastSquaresSimulation from "./LeastSquaresSimulation";

--- a/src/components/LeastSquares/LeastSquaresChart.js
+++ b/src/components/LeastSquares/LeastSquaresChart.js
@@ -2,11 +2,6 @@
 
   Displays a HighCharts scatterplot for the Least Squares data points
 
-  props:
-    points         - array
-    linePoints     - array
-    setSquareAreas - callback
-
 */
 import React, { useEffect, useState } from 'react';
 import '../../styles/dark-unica.css';
@@ -15,7 +10,7 @@ import HighchartsReact from 'highcharts-react-official'
 import 'highcharts/modules/annotations';
 import { abs } from "mathjs";
 import PropTypes from 'prop-types';
-
+import { xyPointsType } from "../../lib/types.js"
 
 export default function LeastSquaresChart({ points, linePoints, setSquareAreas }) {
   const [myChart, setMyChart] = useState({
@@ -149,9 +144,7 @@ export default function LeastSquaresChart({ points, linePoints, setSquareAreas }
 }
 
 LeastSquaresChart.propTypes = {
-
-  points : PropTypes.array,
-  linePoints: PropTypes.array,
-  setSquareAreas : PropTypes.func,
-
+  points: xyPointsType.isRequired,
+  linePoints: xyPointsType.isRequired,
+  setSquareAreas: PropTypes.func.isRequired
 }

--- a/src/components/LeastSquares/LeastSquaresSimulation.js
+++ b/src/components/LeastSquares/LeastSquaresSimulation.js
@@ -2,9 +2,6 @@
 
   Displays the Least Squares simulation
 
-  props:
-    none
-
 */
 import React, { useEffect, useState } from "react";
 import { Row, Col } from "reactstrap";

--- a/src/components/LeastSquares/NewPointsInput.js
+++ b/src/components/LeastSquares/NewPointsInput.js
@@ -34,6 +34,7 @@ export default function NewPointsInput({ generatePoints }) {
     </InputGroup>
   );
 }
+
 NewPointsInput.propTypes = {
   generatePoints: PropTypes.func.isRequired,
 }

--- a/src/components/LeastSquares/NewPointsInput.js
+++ b/src/components/LeastSquares/NewPointsInput.js
@@ -2,9 +2,6 @@
 
   Displays a slider for the user to choose a number of random points and a button to generate them
 
-  props:
-    generatePoints - callback
-
 */
 import React, {  useState } from "react";
 import { Button, Input, InputGroup, InputGroupAddon, InputGroupText } from "reactstrap";

--- a/src/components/LeastSquares/PlotLine.js
+++ b/src/components/LeastSquares/PlotLine.js
@@ -24,6 +24,7 @@ export default function PlotLine({ stage, setStage, squareAreas, generateBestLin
         </div>
   );
 }
+
 PlotLine.propTypes = {
   stage: PropTypes.number.isRequired,
   setStage: PropTypes.func.isRequired,

--- a/src/components/OmittedVariableBias/CoefficientInput.js
+++ b/src/components/OmittedVariableBias/CoefficientInput.js
@@ -36,9 +36,8 @@ export default function CoefficientInput({ beta, setBeta, delta, setDelta }){
   );
 }
 CoefficientInput.propTypes = {
-
-  beta: PropTypes.number,
-  setBeta : PropTypes.func,
-  delta : PropTypes.number,
-  setDelta : PropTypes.func,
+  beta: PropTypes.number.isRequired,
+  setBeta: PropTypes.func.isRequired,
+  delta: PropTypes.number.isRequired,
+  setDelta: PropTypes.func.isRequired,
 }

--- a/src/components/OmittedVariableBias/CoefficientInput.js
+++ b/src/components/OmittedVariableBias/CoefficientInput.js
@@ -35,6 +35,7 @@ export default function CoefficientInput({ beta, setBeta, delta, setDelta }){
     </div>
   );
 }
+
 CoefficientInput.propTypes = {
   beta: PropTypes.number.isRequired,
   setBeta: PropTypes.func.isRequired,

--- a/src/components/OmittedVariableBias/OVBSimulation.js
+++ b/src/components/OmittedVariableBias/OVBSimulation.js
@@ -15,7 +15,6 @@ const stdY = 6;
 const OBS = 1000;
 const INT = 40;
 
-
 export default function OVBSimulation() {
   const [beta, setBeta] = useState(3);
   const [delta, setDelta] = useState(3);
@@ -145,11 +144,10 @@ export default function OVBSimulation() {
       <Row>
         <Col>
           <p>Estimate Regression Using Test Score and Study Hours Data </p>
-          <Button color='primary' onClick={() => generateSeries()}>Generate!</Button>
+          <Button color="primary" onClick={() => generateSeries()}>Generate!</Button>
         </Col>
       </Row>
-      {
-        (stage >= 2) &&
+      {(stage >= 2) && (
         <div>
           <Row>
             <Col>
@@ -162,12 +160,12 @@ export default function OVBSimulation() {
           </Row>
           <Row>
             <Col>
-              <p color='primary'>Add Omitted Variable, Density, to Regression</p>
-              <Button outline color='primary' onClick={() => setShowCorrect(true)}>Show Corrected Regression Line</Button>
+              <p color="primary">Add Omitted Variable, Density, to Regression</p>
+              <Button outline color="primary" onClick={() => setShowCorrect(true)}>Show Corrected Regression Line</Button>
             </Col>
           </Row>
         </div>
-      }
+      )}
     </div>
   );
 }

--- a/src/components/OmittedVariableBias/OmittedVariableChart.js
+++ b/src/components/OmittedVariableBias/OmittedVariableChart.js
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official'
 import PropTypes from 'prop-types';
+import { popArrayType } from '../../lib/types';
 
-export default function LeastSquaresChart({ dataPoints, naiveLine, correctedLine }) {
-
+export default function OmittedVariableChart({ dataPoints, naiveLine, correctedLine }) {
   const [myChart, setMyChart] = useState({});
+
+  console.log(dataPoints, naiveLine, correctedLine)
 
   useEffect(() => {
     const newChart = {
@@ -66,9 +68,8 @@ export default function LeastSquaresChart({ dataPoints, naiveLine, correctedLine
   );
 }
 
-LeastSquaresChart.propTypes = {
-
-  dataPoints : PropTypes.array,
-  naiveLine: PropTypes.array,
-  correctedLine: PropTypes.array,
+OmittedVariableChart.propTypes = {
+  dataPoints: popArrayType.isRequired,
+  naiveLine: PropTypes.arrayOf(PropTypes.number),
+  correctedLine: PropTypes.arrayOf(PropTypes.number)
 }

--- a/src/components/OmittedVariableBias/OmittedVariableChart.js
+++ b/src/components/OmittedVariableBias/OmittedVariableChart.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official'
 import PropTypes from 'prop-types';
-import { popArrayType } from '../../lib/types';
+import { popArrayType } from '../../lib/types.js';
 
 export default function OmittedVariableChart({ dataPoints, naiveLine, correctedLine }) {
   const [myChart, setMyChart] = useState({});

--- a/src/components/PopBar.js
+++ b/src/components/PopBar.js
@@ -2,10 +2,6 @@
   Allows the user to select simulation variations
 
   Used by Law of Large Numbers and Central Limit Theorem
-
-  props:
-    sim     - string
-    setPop  - callback
 */
 import React, { useState } from 'react';
 import { Button} from 'reactstrap';
@@ -42,7 +38,6 @@ export default function PopBar({ sim, setPop }) {
 }
 
 PopBar.propTypes = {
-
-  sim : PropTypes.string,
-  setPop : PropTypes.func,
+  sim: PropTypes.string.isRequired,
+  setPop: PropTypes.func.isRequired,
 }

--- a/src/components/PopTable.js
+++ b/src/components/PopTable.js
@@ -54,8 +54,8 @@ export default function PopTable(props) {
                 <Table striped className="PopTable">
                     <thead>
                         <tr>
-                            <th>{props.popType && values[props.popType].xLabel}</th>
-                            <th>{props.popType && values[props.popType].yLabel}</th>
+                            <th>{props.popShape && values[props.popShape].xLabel}</th>
+                            <th>{props.popShape && values[props.popShape].yLabel}</th>
                         </tr>
                     </thead>
                     {tableBody}

--- a/src/components/SampleSizeInput.js
+++ b/src/components/SampleSizeInput.js
@@ -4,10 +4,6 @@
 
   Used by Law of Large Numbers and Central Limit Theorem
 
-  props:
-    maxSize     - int
-    handleClick - callback
-
 */
 import React, { useState } from 'react';
 import { Button, Input, InputGroup, InputGroupAddon } from 'reactstrap';
@@ -36,7 +32,6 @@ export default function SampleSizeInput({ maxSize, handleClick }) {
   );
 }
 SampleSizeInput.propTypes = {
-
-  maxSize : PropTypes.number,
-  handleClick: PropTypes.func,
+  maxSize: PropTypes.number.isRequired,
+  handleClick: PropTypes.func.isRequired,
 }

--- a/src/components/SampleSizeInput.js
+++ b/src/components/SampleSizeInput.js
@@ -31,6 +31,7 @@ export default function SampleSizeInput({ maxSize, handleClick }) {
     </InputGroup>
   );
 }
+
 SampleSizeInput.propTypes = {
   maxSize: PropTypes.number.isRequired,
   handleClick: PropTypes.func.isRequired,

--- a/src/components/SelectorButtonGroup.js
+++ b/src/components/SelectorButtonGroup.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { ButtonGroup, Button } from "reactstrap";
+import PropTypes from "prop-types";
 
 export default function SelectorButtonGroup({ options, select, selected }) {
   const buttons = options.map((option) =>
@@ -17,4 +18,10 @@ export default function SelectorButtonGroup({ options, select, selected }) {
       {buttons}
     </ButtonGroup>
   )
+}
+
+SelectorButtonGroup.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  select: PropTypes.func.isRequired,
+  selected: PropTypes.string
 }

--- a/src/components/SimBar.js
+++ b/src/components/SimBar.js
@@ -2,9 +2,6 @@
 
   Displays a menu with all the simulations and allows the user to click to start them
 
-  props:
-    setSection - callback function
-
 */
 import React from 'react';
 import clt from '../images/clt.png';
@@ -76,6 +73,5 @@ export default function SimBar({ setSection }) {
   );
 }
 SimBar.propTypes = {
-
- setSection : PropTypes.func,
+  setSection: PropTypes.func.isRequired,
 }

--- a/src/components/SimBar.js
+++ b/src/components/SimBar.js
@@ -4,11 +4,6 @@
 
 */
 import React from 'react';
-import clt from '../images/clt.png';
-import lln from '../images/lln.png';
-import jd from '../images/jd.jpg';
-import ls from '../images/ls.png';
-import ovs from '../images/ovs.png';
 import SimBarOption from './SimBarOption';
 import PropTypes from 'prop-types'
 

--- a/src/components/SimBar.js
+++ b/src/components/SimBar.js
@@ -18,44 +18,30 @@ export default function SimBar({ setSection }) {
     {
       name: 'Law of Large Numbers',
       description: 'The Law of Large Numbers tells us that that the sample mean approaches the mean of the population as we increase the sample size. This simulation investigates the behavior of the sample mean as we change the sample size.',
-      extra: "",
-      img: lln
     },
     {
       name: "Central Limit Theorem",
       description: "The Central Limit Theorem states that, for sufficiently large samples, the sample mean is approximately normally distributed, even if the underlying population is not normally distributed (or if we have no idea what the underlying population looks like). This simulation investigates how the distribution of the sample mean is affected by the sample size and the shape of the population distribution.",
-      extra: "",
-      img: clt
     },
     {
       name: "Joint Distributions",
       description: "A joint probability distribution describes the simultaneous behavior of two random variables.",
-      extra: "",
-      img: jd
     },
     {
       name: "Least Squares",
       description: "Ordinary least squares regression estimates the slope(s) and intercept of a line to best fit data for two (or more) variables by minimizing the sum of the squared distances from the data points to the line.",
-      extra: "",
-      img: ls
     },
     {
       name: "Omitted Variable Bias",
       description: "Omitted variable bias (OVB) arises when a variable that is i) correlated with the outcome and ii) correlated with one on the included regressors is omitted from the regression model.",
-      extra: "",
-      img: ovs
     },
     {
       name: "Confidence Intervals",
       description: "A confidence interval provides a range of values for the likely location of the true population mean, based on information gathered from a sample.",
-      extra: "",
-      img: undefined
     },
     // {
     //   name: "Hypothesis Testing",
     //   description: "test",
-    //   extra: "",
-    //   img: undefined
     // }
   ];
 
@@ -72,6 +58,7 @@ export default function SimBar({ setSection }) {
     </div>
   );
 }
+
 SimBar.propTypes = {
   setSection: PropTypes.func.isRequired,
 }

--- a/src/components/SimBarOption.js
+++ b/src/components/SimBarOption.js
@@ -12,7 +12,11 @@ export default function SimBarOption({ section, setSection }) {
     </Card>
   );
 }
+
 SimBarOption.propTypes = {
   setSection: PropTypes.func.isRequired,
-  section: PropTypes.object.isRequired,
+  section: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string
+  }).isRequired,
 }

--- a/src/components/SimBarOption.js
+++ b/src/components/SimBarOption.js
@@ -13,7 +13,6 @@ export default function SimBarOption({ section, setSection }) {
   );
 }
 SimBarOption.propTypes = {
-
-  setSection : PropTypes.func,
-  section : PropTypes.object,
+  setSection: PropTypes.func.isRequired,
+  section: PropTypes.object.isRequired,
 }

--- a/src/components/SimulationContainer.js
+++ b/src/components/SimulationContainer.js
@@ -13,7 +13,6 @@ import JointDistributions from './JointDistributions/JointDistributions.js';
 import OmittedVariableBias from "./OmittedVariableBias/OmittedVariableBias.js";
 import ConfidenceIntervals from './ConfidenceIntervals/ConfidenceIntervals.js';
 import HypothesisTesting from './HypothesisTesting/HypothesisTesting.js';
-import StartHere from './StartHere';
 import { Button } from 'reactstrap';
 import LeastSquares from './LeastSquares/LeastSquares.js';
 import PropTypes from 'prop-types';
@@ -22,8 +21,7 @@ export default function SimulationContainer({ mode, setMode }) {
   return (
     <div className="App">
       <Button outline color='danger' id="Menu" onClick={() => setMode("Home")}>MENU</Button>
-      <div className="MiniLogo"></div>
-      {mode === 'Start Here' && <StartHere/>}
+      <div className="MiniLogo"/>
       {mode === 'Law of Large Numbers' && <LawOfLargeNumbers/>}
       {mode === 'Central Limit Theorem' && <CentralLimitTheorem/>}
       {mode === 'Joint Distributions' && <JointDistributions/>}
@@ -36,9 +34,15 @@ export default function SimulationContainer({ mode, setMode }) {
 }
 
 SimulationContainer.propTypes = {
-
-  setMode : PropTypes.func,
-  mode : PropTypes.oneOf(['Home','Law of Large Numbers','Central Limit Theorem', 'Joint Distributions',
-  'Least Squares','Omitted Variable Bias', 'Start Here', 'Confidence Intervals' , 'Hypothesis Testing' ]),
-
+  setMode: PropTypes.func.isRequired,
+  mode: PropTypes.oneOf([
+    'Home',
+    'Law of Large Numbers',
+    'Central Limit Theorem',
+    'Joint Distributions',
+    'Least Squares',
+    'Omitted Variable Bias',
+    'Confidence Intervals',
+    'Hypothesis Testing'
+  ]).isRequired,
 }

--- a/src/components/SimulationMenu.js
+++ b/src/components/SimulationMenu.js
@@ -2,8 +2,6 @@
 
   Displays the StartHere button and then the menu once the button is clicked
 
-  props:
-    none
 */
 import React, { useEffect, useState } from 'react';
 import SimBar from './SimBar.js';
@@ -30,17 +28,15 @@ export default function SimulationMenu() {
       </div>
     ) : (
       <div>
-        {
-          (mode === "Home") ? (
-            <Fade in={(mode === "Home")} style={{ display: (mode === "Home") ? 'block' : 'none' }}>
-              <div className="Nav" key={'unkey'}>
-                <SimBar setSection={setMode}/>
-              </div>
-            </Fade>
-          ) : (
-            <SimulationContainer mode={mode} setMode={setMode}/>
-          )
-        }
+        {(mode === "Home") ? (
+          <Fade in={(mode === "Home")} style={{ display: (mode === "Home") ? 'block' : 'none' }}>
+            <div className="Nav" key={'unkey'}>
+              <SimBar setSection={setMode}/>
+            </div>
+          </Fade>
+        ) : (
+          <SimulationContainer mode={mode} setMode={setMode}/>
+        )}
       </div>
     )
   );

--- a/src/components/StartHere.js
+++ b/src/components/StartHere.js
@@ -2,11 +2,7 @@
 
   Displays the introduction to the website and the start button
 
-  props:
-    start   - boolean
-    showApp - callback
 */
-
 import React from 'react';
 import { Button, Fade } from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -26,8 +22,6 @@ export default function StartHere({ start, showApp }) {
 }
 
 StartHere.propTypes = {
-
-  showApp : PropTypes.func.isRequired,
-  start : PropTypes.bool.isRequired,
-
+  start: PropTypes.bool.isRequired,
+  showApp: PropTypes.func.isRequired,
 }

--- a/src/lib/stats-utils.js
+++ b/src/lib/stats-utils.js
@@ -118,11 +118,6 @@ export const generateMystery = (sampleSize) => {
       }
       popArray.push(round((sum / secondITERATES)*100)/100)
   }
-  if(clearedArray.length > 0){
-    var tempCleared = clearedArray;
-    tempCleared = newCleared;
-    this.setState({clearedArray : tempCleared});
-  }
 
   const finalPopArray = [];
 

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -42,4 +42,4 @@ export const confidenceIntervalsSampleType = PropTypes.shape({
   id: PropTypes.number.isRequired
 });
 
-export const stringOrNumberType = PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+export const stringOrNumberType = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -41,3 +41,5 @@ export const confidenceIntervalsSampleType = PropTypes.shape({
   label: PropTypes.bool.isRequired,
   id: PropTypes.number.isRequired
 });
+
+export const stringOrNumberType = PropTypes.oneOfType([PropTypes.string, PropTypes.number])

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+
+export const popShapeType = PropTypes.oneOf([
+  "Normal",
+  "Uniform",
+  "Exponential",
+  "Chi-Squared",
+  "Mystery"
+]);
+
+export const popArrayType = PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number));
+
+export const sampleMeansType = PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number));
+
+export const dotPlotSeriesType = PropTypes.arrayOf(
+  PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    data: popArrayType.isRequired,
+    type: PropTypes.string,
+    color: PropTypes.string,
+    enableMouseTracking: PropTypes.bool,
+    showInLegend: PropTypes.bool,
+    visible: PropTypes.bool,
+    label: PropTypes.object
+  })
+);

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -10,9 +10,7 @@ export const popShapeType = PropTypes.oneOf([
 
 export const popArrayType = PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number));
 
-export const sampleMeansType = PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number));
-
-export const dotPlotSeriesType = PropTypes.arrayOf(
+export const highchartsSeriesType = PropTypes.arrayOf(
   PropTypes.shape({
     name: PropTypes.string.isRequired,
     data: popArrayType.isRequired,

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -25,7 +25,7 @@ export const dotPlotSeriesType = PropTypes.arrayOf(
   })
 );
 
-export const jointDistributionsDataType = PropTypes.arrayOf(
+export const xyPointsType = PropTypes.arrayOf(
   PropTypes.shape({
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -31,3 +31,15 @@ export const xyPointsType = PropTypes.arrayOf(
     y: PropTypes.number.isRequired
   })
 );
+
+export const confidenceIntervalsSampleType = PropTypes.shape({
+  data: popArrayType.isRequired,
+  size: PropTypes.number.isRequired,
+  mean: PropTypes.number.isRequired,
+  lowerConf: PropTypes.number.isRequired,
+  upperConf: PropTypes.number.isRequired,
+  confidenceLevel: PropTypes.number.isRequired,
+  distribution: PropTypes.oneOf(["Z","T"]).isRequired,
+  label: PropTypes.bool.isRequired,
+  id: PropTypes.number.isRequired
+});

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -24,3 +24,10 @@ export const dotPlotSeriesType = PropTypes.arrayOf(
     label: PropTypes.object
   })
 );
+
+export const jointDistributionsDataType = PropTypes.arrayOf(
+  PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired
+  })
+);


### PR DESCRIPTION
All PropTypes should now be correctly labeled as `isRequired` if necessary.

I also created a new file `src/lib/types.js` that holds PropTypes for the more complex array and object shapes that can be imported when needed.