### PR TITLE
Standardize button

### DIFF
--- a/src/components/HypothesisTesting/PerformTest.js
+++ b/src/components/HypothesisTesting/PerformTest.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { sqrt } from "mathjs";
+import { random, sqrt } from "mathjs";
 import { Button, Container, Row } from "reactstrap";
 import { dataFromDistribution, populationMean, populationStandardDev } from "../../lib/stats-utils.js";
 import PropTypes from "prop-types";
@@ -33,8 +33,8 @@ export default function PerformTest({ distType, shape, sides, mu0, equality, tes
 
 
   useEffect(() => {
-    const popMean1 = Math.random(61,66);
-    const popMean2 = Math.random(61,66);
+    const popMean1 = random(61, 66);
+    const popMean2 = random(61, 66);
     setPopArr(dataFromDistribution(shape, 2000, { mean: popMean1, low: 59, hi: 79 }))
     setPopArr2(dataFromDistribution(shape, 2000, { mean: popMean2 , low: 59, hi: 79 }))
   }, [shape]);

--- a/src/components/HypothesisTesting/SimulateTypeOneError.js
+++ b/src/components/HypothesisTesting/SimulateTypeOneError.js
@@ -3,17 +3,19 @@ import { dataFromDistribution, populationMean, populationStandardDev } from "../
 import DotPlot from "../DotPlot.js";
 import NormalCurve from "./NormalCurve.js";
 import ManySamplesInput from "./ManySamplesInput.js";
-import { Container, Row, Col, Alert } from "reactstrap";
+import { Container, Row, Col, Alert, Input, Label } from "reactstrap";
 import _ from "lodash";
 import { jStat } from "jstat";
 import PropTypes from "prop-types";
 import { distributionType, popShapeType } from "../../lib/types.js";
 import { sqrt } from "mathjs";
+import StdNormalCurve from "./StdNormalCurve.js";
 
 export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, sides, equality }) {
   const [population, setPopulation] = useState([]);
   const [sampleMeans, setSampleMeans] = useState([]);
   const [sampleSize, setSampleSize] = useState(0);
+  const [normalized, setNormalized] = useState(false);
 
   useEffect(() => {
     setPopulation(dataFromDistribution(popShape, 2000, { mean: mu0, standardDev: 3, low: mu0 - 10, hi: mu0 + 10 }))
@@ -60,13 +62,25 @@ export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, s
           <DotPlot series={[{name: "Population", data: population, showInLegend: false}]} title="Population" xLabel="Gallons"/>
         </Col>
         <Col>
-          <NormalCurve
-            means={sampleMeans}
-            mu0={mu0}
-            popStandardDev={_.defaultTo(populationStandardDev(population), 0)}
-            sampleSize={+sampleSize || 1}
-            distType={distType}
-          />
+          {!normalized ? (
+            <NormalCurve
+              means={sampleMeans}
+              mu0={mu0}
+              popStandardDev={_.defaultTo(populationStandardDev(population), 0)}
+              sampleSize={+sampleSize || 1}
+              distType={distType}
+            />
+          ) : (
+            <StdNormalCurve
+              means={sampleMeans}
+              sampleSize={+sampleSize || 1}
+              distType={distType}
+            />
+          )}
+          <Label>
+            <Input type="checkbox" onClick={() => setNormalized(!normalized)}/>
+            {" "}Normalized
+          </Label>
         </Col>
       </Row>
       <ManySamplesInput populationSize={population.length} addSamples={addSamples}/>

--- a/src/components/HypothesisTesting/SimulateTypeOneError.js
+++ b/src/components/HypothesisTesting/SimulateTypeOneError.js
@@ -15,7 +15,7 @@ export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, s
   const [population, setPopulation] = useState([]);
   const [sampleMeans, setSampleMeans] = useState([]);
   const [sampleSize, setSampleSize] = useState(0);
-  const [normalized, setNormalized] = useState(false);
+  const [standardized, setStandardized] = useState(false);
 
   useEffect(() => {
     setPopulation(dataFromDistribution(popShape, 2000, { mean: mu0, standardDev: 3, low: mu0 - 10, hi: mu0 + 10 }))
@@ -62,7 +62,7 @@ export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, s
           <DotPlot series={[{name: "Population", data: population, showInLegend: false}]} title="Population" xLabel="Gallons"/>
         </Col>
         <Col>
-          {!normalized ? (
+          {!standardized ? (
             <NormalCurve
               means={sampleMeans}
               mu0={mu0}
@@ -78,8 +78,8 @@ export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, s
             />
           )}
           <Label>
-            <Input type="checkbox" onClick={() => setNormalized(!normalized)}/>
-            {" "}Normalized
+            <Input type="checkbox" onClick={() => setStandardized(!standardized)}/>
+            {" "}Standardized
           </Label>
         </Col>
       </Row>

--- a/src/components/HypothesisTesting/StdNormalCurve.js
+++ b/src/components/HypothesisTesting/StdNormalCurve.js
@@ -11,9 +11,9 @@ import { sqrt } from "mathjs";
 BellCurve(Highcharts);
 
 
-export default function NormalCurve({ means, mu0, popStandardDev, sampleSize, distType }) {
-  const [population, setPopulation] = useState(
-    dataFromDistribution("Normal", 2000, { mean: mu0, standardDev: popStandardDev / sqrt(sampleSize) })
+export default function StdNormalCurve({ means, sampleSize, distType }) {
+  const [population] = useState(
+    dataFromDistribution("Normal", 2000, { mean: 0, standardDev: 1 })
   );
   const [chart, setChart] = useState({
     chart: {
@@ -32,7 +32,7 @@ export default function NormalCurve({ means, mu0, popStandardDev, sampleSize, di
     },
     xAxis: {
       title: {
-        text: "Gallons",
+        text: "Test Statistic",
       },
       startOnTick: true,
       endOnTick: true
@@ -43,13 +43,9 @@ export default function NormalCurve({ means, mu0, popStandardDev, sampleSize, di
       title: false
     },
     tooltip: {
-      pointFormat: "sample mean: <b>{point.mean}</b><br/>test statistic: <b>{point.testStatistic}</b><br/>reject H_0: <b>{point.reject}</b></br>"
+      pointFormat: "test statistic: <b>{point.testStatistic}</b><br/>sample mean: <b>{point.mean}</b><br/>reject H_0: <b>{point.reject}</b></br>"
     }
   });
-
-  useEffect(() => {
-    setPopulation(dataFromDistribution("Normal", 2000, { mean: mu0, standardDev: popStandardDev / sqrt(sampleSize) }))
-  }, [mu0, popStandardDev, sampleSize]);
 
   useEffect(() => {
     const meanCounts = {};
@@ -58,7 +54,7 @@ export default function NormalCurve({ means, mu0, popStandardDev, sampleSize, di
     means.forEach(({ testStatistic, mean, reject }) => {
       meanCounts[mean] = _.defaultTo(meanCounts[mean] + 1, 1);
       const meanObject = {
-        x: mean,
+        x: testStatistic,
         y: meanCounts[mean] * ((distType === "T") ? 1 : 0.005 * sqrt(sampleSize)),
         testStatistic,
         mean,
@@ -125,10 +121,8 @@ export default function NormalCurve({ means, mu0, popStandardDev, sampleSize, di
   return <HighchartsReact highcharts={Highcharts} options={chart}/>
 }
 
-NormalCurve.propTypes = {
+StdNormalCurve.propTypes = {
   means: hypothesisTestingSampleArrayType.isRequired,
-  mu0: PropTypes.number.isRequired,
-  popStandardDev: PropTypes.number.isRequired,
   sampleSize: PropTypes.number.isRequired,
   distType: distributionType.isRequired
 }


### PR DESCRIPTION
I added a simple checkbox that converts the curve to a standard normal curve and plots the test statistic instead of the sample mean.

However, I'm not quite sure this adds much to the simulation, as it is essentially the same graph with different x-axis ticks (unless of course I made a mistake, which is definitely a possibility). Perhaps some visual change is needed.

closes #89 