### PR TITLE
Adjust linter configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,47 +1,49 @@
 {
-  "extends": ["airbnb", "airbnb/hooks"],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
   "env": {
     "node": true,
     "jest": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
-    "max-len": "off",
     "no-plusplus": [
       "warn",
       {
         "allowForLoopAfterthoughts": true
       }
     ],
-    "object-curly-newline": "off",
-    "no-mixed-operators": "off",
     "prefer-template": "warn",
-    "no-else-return": "off",
-    "prefer-destructuring": "warn",
+    "prefer-destructuring": [
+      "warn",
+      {
+        "array": true,
+        "object": true
+      }
+    ],
     "curly": "warn",
-    "jsx-quotes": ["error", "prefer-double"],
-    "comma-dangle": "off",
-    "operator-linebreak": "off",
-    "semi": "off",
+    "quotes": ["warn", "single"],
+    "jsx-quotes": ["warn", "prefer-double"],
     "object-shorthand": "warn",
-    "function-paren-newline": "off",
-    "implicit-arrow-linebreak": "off",
     "react/jsx-tag-spacing": [
-      "error",
+      "warn",
       {
         "beforeSelfClosing": "allow"
       }
     ],
     "react/jsx-boolean-value": ["warn", "never"],
-    "react/jsx-one-expression-per-line": "off",
-    "react/jsx-filename-extension": "off",
-    "react/react-in-jsx-scope": "off",
-    "react/require-default-props": "off",
-    "react/no-this-in-sfc": "off",
     "react/no-array-index-key": "warn",
     "react/no-unused-state": "warn",
-    "react/jsx-props-no-spreading": "off",
-    "import/no-extraneous-dependencies": "off",
-    "import/extensions": "off",
-    "import/order": "off"
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,54 +6236,6 @@
         }
       }
     },
-    "eslint-config-airbnb": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
-      "dev": true,
-      "requires": {
-        "eslint-config-airbnb-base": "^14.2.1",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
-      },
-      "dependencies": {
-        "object.entries": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-          "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.18.2"
-          }
-        }
-      }
-    },
-    "eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
-      "dev": true,
-      "requires": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
-      },
-      "dependencies": {
-        "object.entries": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-          "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.18.2"
-          }
-        }
-      }
-    },
     "eslint-config-react-app": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
@@ -6579,12 +6531,6 @@
           }
         }
       }
-    },
-    "eslint-plugin-react-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-      "dev": true
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",

--- a/package.json
+++ b/package.json
@@ -55,10 +55,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "eslint": "^7.30.0",
-    "eslint-config-airbnb": "^18.2.1",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
     "prettier": "^2.3.1"
   },
   "husky": {

--- a/src/components/OmittedVariableBias/OVBSimulation.js
+++ b/src/components/OmittedVariableBias/OVBSimulation.js
@@ -61,9 +61,7 @@ export default function OVBSimulation() {
       }
 
       // regress study hours with test scores
-      const naiveReg = regression.linear(studyScores);
-      const naiveSlope = (naiveReg.equation[0]);
-      const naiveInt = (naiveReg.equation[1]);
+      const [naiveSlope, naiveInt] = regression.linear(studyScores).equation;
 
       // Corrected regression
 


### PR DESCRIPTION
Turns out the linter settings I configured yesterday added a lot of rules by default that would cause compilation errors, so we would need to manually disable them all as they appeared. I've re-configured the `.eslintrc.json` file to disable more rules by default and allow us to toggle rules that we want to enforce.