### PR TITLE
Fix mean and standard deviation of original population

### DIFF
--- a/src/components/HypothesisTesting/PerformTest.js
+++ b/src/components/HypothesisTesting/PerformTest.js
@@ -45,21 +45,7 @@ export default function PerformTest({ distType, shape, sides, mu0, equality, tes
       }
     ));
     if (testType === 'twoSample') {
-      const sd2 = random(1, 4);
-      setOriginalPop(dataFromDistribution(
-        shape,
-        2000,
-        {
-          mean: 64,
-          standardDev: sd2,
-          low: 54,
-          hi: 74,
-          mysteryMean1: 58,
-          mysteryMean2: 70,
-          mysterySD1: sd2 - 1,
-          mysterySD2: sd2 + 1
-        }
-      ));
+      setOriginalPop(dataFromDistribution(shape, 2000, { low: 54, hi: 74 }));
     } else {
       setOriginalPop([]);
     }

--- a/src/components/HypothesisTesting/PopulationChartReveal.js
+++ b/src/components/HypothesisTesting/PopulationChartReveal.js
@@ -8,7 +8,9 @@ import { max } from 'mathjs';
 export default function PopulationChartReveal({ popArr, popArr2, pVal, alpha, mu0 }) {
   const popMean = populationMean(popArr);
   const popMean2 = populationMean(popArr2);
-  const maxHeight = max(max(popArr.map(({ y }) => y)), (popArr2.length > 0) ? max(popArr2.map(({ y }) => y)) : 0);
+  const popArrMax = (popArr.length > 0) ? max(popArr.map(({ y }) => y)) : 0;
+  const popArr2Max = (popArr2.length > 0) ? max(popArr2.map(({ y }) => y)) : 0;
+  const maxHeight = max(popArrMax, popArr2Max);
 
   const series = [
     {
@@ -36,7 +38,7 @@ export default function PopulationChartReveal({ popArr, popArr2, pVal, alpha, mu
       enableMouseTracking: false,
       showInLegend: false,
       label: {
-        format: `<div>${(popArr2.length === 0) ? 'True Population Mean' : 'First Population Mean'}: ${popMean.toFixed(2)}</div>`
+        format: `<div>${(popArr2.length === 0) ? 'True Population Mean' : 'First Population Mean'}: ${popMean && popMean.toFixed(2)}</div>`
       }
     },
     {
@@ -54,7 +56,7 @@ export default function PopulationChartReveal({ popArr, popArr2, pVal, alpha, mu
     {
       type: 'line',
       name: 'Mu_0',
-      data: [{ x: mu0 || 0, y: 0 }, { x: mu0 || 0, y: max(popArr.map(({ y }) => y)) }],
+      data: [{ x: mu0 || 0, y: 0 }, { x: mu0 || 0, y: popArrMax }],
       color: 'red',
       enableMouseTracking: false,
       showInLegend: false,


### PR DESCRIPTION
The Hypothesis testing module now does the following:

> 1. In the one-sample test, let's randomize the population mean and standard deviation.
> 2. In the two-sample case, let's fix the mean and std. dev of population 1 and randomize the mean and std. dev. for population 2.

I also renamed some variables to make it clear that what was previously the "second" population is now the "original" population

closes #111 