### PR TITLE
Simulate type 1 error

### DIFF
--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -35,7 +35,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
       const fObject = {
         x: _.round(F, 3),
         y: fCounts[F],
-        F: F.toPrecision(3),
+        F: _.round(F, 3),
         pValue: pValue.toPrecision(3),
         reject,
       }

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -112,6 +112,11 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
         />
       )}
       </Alert>
+      {([...accepts, ...rejects].length > 0) && (
+        <Alert variant="primary">
+          {`We rejected the null hypothesis in ${100 * rejects.length / (rejects.length + accepts.length)}% of replications.`}
+        </Alert>
+      )}
     </>
   )
 }

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -22,10 +22,10 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
       const SSTR = sum(samples.map((sample) => sample.length * (mean(sample) - overallSampleMean) ** 2));
       const MSTR = SSTR / (populations.length - 1);
       const SSE = sum(samples.map((sample) => (sample.length - 1) * std(sample) ** 2));
-      const MSE = SSE / (sum(populations.map(({ data }) => data.length)) - populations.length);
+      const MSE = SSE / (sum(samples.map((sample) => sample.length)) - populations.length);
       const F = MSTR / MSE;
       const pValue = jStat.anovaftest(...samples);
-      fStats.push({ F: (F < 1) ? +F.toPrecision(2) : _.round(F, 1), pValue, reject: pValue < +alpha });
+      fStats.push({ F: _.round(F, 2), pValue, reject: pValue < +alpha });
     }
     const fCounts = {};
     const newRejects = [];

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -129,7 +129,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
         <>
           <p>
             <strong>Distribution of F-Statistic </strong>
-            (<InlineMath math={`df_{num} = ${populations.length}, df_{den} = ${sum(populations.map(({ sampleSize }) => sampleSize)) - populations.length}`}/>)
+            (<InlineMath math={`df_{num} = ${populations.length - 1}, df_{den} = ${sum(populations.map(({ sampleSize }) => sampleSize)) - populations.length}`}/>)
           </p>
           <HighchartsReact highcharts={Highcharts} options={chart}/>
         </>

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -4,8 +4,9 @@ import { anovaPopulationObjectType, stringOrNumberType } from '../../lib/types';
 import { Alert, Button, Form, InputGroup } from 'react-bootstrap';
 import _ from 'lodash';
 import { mean, std, sum } from 'mathjs';
-import DotPlot from '../DotPlot';
 import { jStat } from 'jstat';
+import HighchartsReact from 'highcharts-react-official';
+import Highcharts from 'highcharts';
 
 export default function DistributionOfFStatistic({ populations, alpha }) {
   const [numSamples, setNumSamples] = useState('');
@@ -48,38 +49,60 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
     setRejects(newRejects);
   }
 
-  const tooltipFormat = {
-    pointFormat: 'F-Statistic: <b>{point.F}</b><br/>p-value: <b>{point.pValue}</b><br/>reject H_0: <b>{point.reject}</b></br>'
-  }
-
-  const series = [
-    {
-      name: 'Fail to Reject H_0',
-      type: 'scatter',
-      data: accepts,
-      color: '#03fc0b',
-      marker: {
-        symbol: 'diamond',
-        radius: 4,
-        lineColor: 'green',
-        lineWidth: 1
-      },
-      tooltip: tooltipFormat
+  const chart = {
+    chart: {
+      zoomType: 'xy',
+      animation: false,
+      type: 'scatter'
     },
-    {
-      name: 'Reject H_0',
-      type: 'scatter',
-      data: rejects,
-      color: 'red',
-      marker: {
-        symbol: 'diamond',
-        radius: 4,
-        lineColor: '#800000',
-        lineWidth: 1
+    title: {
+      text: 'Distribution of F-Statistic'
+    },
+    xAxis: {
+      title: {
+        text: 'F-Statistic',
       },
-      tooltip: tooltipFormat
-    }
-  ]
+      min: 0,
+      startOnTick: true,
+      endOnTick: true
+    },
+    yAxis: {
+      startOnTick: true,
+      endOnTick: true,
+      title: {
+        text: 'Observations of F-Statistic'
+      }
+    },
+    tooltip: {
+      pointFormat: 'F-Statistic: <b>{point.F}</b><br/>p-value: <b>{point.pValue}</b><br/>reject H_0: <b>{point.reject}</b></br>'
+    },
+    series: [
+      {
+        name: 'Fail to Reject H_0',
+        type: 'scatter',
+        data: accepts,
+        color: '#03fc0b',
+        marker: {
+          symbol: 'diamond',
+          radius: 4,
+          lineColor: 'green',
+          lineWidth: 1
+        }
+      },
+      {
+        name: 'Reject H_0',
+        type: 'scatter',
+        data: rejects,
+        color: 'red',
+        marker: {
+          symbol: 'diamond',
+          radius: 4,
+          lineColor: '#800000',
+          lineWidth: 1
+        }
+      }
+    ]
+  }
 
   return (
     <>
@@ -101,16 +124,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
             Simulate
           </Button>
         </InputGroup>
-      {([...accepts, ...rejects].length > 0) && (
-        <DotPlot
-          series={series}
-          title="Distribution of F-Statistic"
-          xLabel="F-Statistic"
-          yLabel="Observations of F-Statistic"
-          xMin={0}
-          zoom
-        />
-      )}
+      {([...accepts, ...rejects].length > 0) && <HighchartsReact highcharts={Highcharts} options={chart}/>}
       </Alert>
       {([...accepts, ...rejects].length > 0) && (
         <Alert variant="primary">

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { anovaPopulationObjectType } from '../../lib/types';
+import { Alert, Button, Form, InputGroup } from 'react-bootstrap';
+import _ from 'lodash';
+import { mean, sum } from 'mathjs';
+import { getCounts, populationMean, populationStandardDev } from '../../lib/stats-utils';
+import DotPlot from '../DotPlot';
+import { jStat } from 'jstat';
+
+export default function DistributionOfFStatistic({ populations }) {
+  const [numSamples, setNumSamples] = useState('');
+  const [fStats, setFStats] = useState([]);
+
+  const runSimulation = () => {
+    const newFStats = [];
+    for (let i = 0; i < numSamples; i++) {
+      const sampleObjects = populations.map(({ data, sampleSize }) => _.sampleSize(data, sampleSize));
+      const samples = sampleObjects.map((sample) => sample.map(({ x }) => x));
+      const overallSampleMean = (_.flatten(samples).length > 0) ? mean(_.flatten(samples)) : undefined;
+      const SSTR = sum(populations.map(({ data }) => data.length * (populationMean(data) - overallSampleMean) ** 2));
+      const MSTR = SSTR / (populations.length - 1);
+      const SSE = sum(populations.map(({ data }) => (data.length - 1) * populationStandardDev(data) ** 2));
+      const MSE = SSE / (sum(populations.map(({ data }) => data.length)) - populations.length);
+      const F = MSTR / MSE;
+      const pValue = jStat.anovaftest(...samples);
+      newFStats.push({ F: F.toPrecision(3), pValue: pValue.toPrecision(3) });
+    }
+    setFStats(newFStats);
+  }
+
+  return (
+    <>
+      <Alert variant="secondary">
+        <p>Let's plot the distribution of the F-Statistic:</p>
+        <InputGroup className="sample-size-input">
+          <Form.Control
+            align="right"
+            type="number"
+            placeholder="Number of Replications:"
+            min={1}
+            value={numSamples}
+            onChange={(event) => setNumSamples(event.target.value)}
+          />
+          <Button
+            variant="secondary"
+            disabled={!numSamples || numSamples < 1} onClick={() => runSimulation()}
+          >
+            Simulate
+          </Button>
+        </InputGroup>
+      {(fStats.length > 0) && (
+        <DotPlot
+          series={[{ name: 'F-Statistics', data: getCounts(fStats.map(({ F }) => F)) }]}
+          title="Distribution of F-Statistic"
+          xLabel="F-Statistic"
+          yLabel="Observations of F-Statistic"
+        />
+      )}
+      </Alert>
+    </>
+  )
+}
+
+DistributionOfFStatistic.propTypes = {
+  populations: PropTypes.arrayOf(anovaPopulationObjectType).isRequired
+}

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -24,7 +24,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
       const MSE = SSE / (sum(populations.map(({ data }) => data.length)) - populations.length);
       const F = MSTR / MSE;
       const pValue = jStat.anovaftest(...samples);
-      fStats.push({ F: _.round(F, 1), pValue, reject: pValue < +alpha });
+      fStats.push({ F: (F < 1) ? +F.toPrecision(2) : _.round(F, 1), pValue, reject: pValue < +alpha });
     }
     const fCounts = {};
     const newRejects = [];
@@ -32,7 +32,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
     fStats.forEach(({ F, pValue, reject }) => {
       fCounts[F] = _.defaultTo(fCounts[F] + 1, 1);
       const fObject = {
-        x: F,
+        x: +F,
         y: fCounts[F],
         F,
         pValue: pValue.toPrecision(3),

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -7,6 +7,7 @@ import { mean, std, sum } from 'mathjs';
 import { jStat } from 'jstat';
 import HighchartsReact from 'highcharts-react-official';
 import Highcharts from 'highcharts';
+import { InlineMath } from 'react-katex';
 
 export default function DistributionOfFStatistic({ populations, alpha }) {
   const [numSamples, setNumSamples] = useState('');
@@ -25,7 +26,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
       const MSE = SSE / (sum(samples.map((sample) => sample.length)) - populations.length);
       const F = MSTR / MSE;
       const pValue = jStat.anovaftest(...samples);
-      fStats.push({ F: _.round(F, 2), pValue, reject: pValue < +alpha });
+      fStats.push({ F: (F < 1) ? +F.toPrecision(2) : _.round(F, 2), pValue, reject: pValue < +alpha });
     }
     const fCounts = {};
     const newRejects = [];
@@ -56,7 +57,7 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
       type: 'scatter'
     },
     title: {
-      text: 'Distribution of F-Statistic'
+      text: ''
     },
     xAxis: {
       title: {
@@ -124,7 +125,15 @@ export default function DistributionOfFStatistic({ populations, alpha }) {
             Simulate
           </Button>
         </InputGroup>
-      {([...accepts, ...rejects].length > 0) && <HighchartsReact highcharts={Highcharts} options={chart}/>}
+      {([...accepts, ...rejects].length > 0) && (
+        <>
+          <p>
+            <strong>Distribution of F-Statistic </strong>
+            (<InlineMath math={`df_{num} = ${populations.length}, df_{den} = ${sum(populations.map(({ sampleSize }) => sampleSize)) - populations.length}`}/>)
+          </p>
+          <HighchartsReact highcharts={Highcharts} options={chart}/>
+        </>
+      )}
       </Alert>
       {([...accepts, ...rejects].length > 0) && (
         <Alert variant="primary">

--- a/src/components/ANOVA/DistributionOfFStatistic.js
+++ b/src/components/ANOVA/DistributionOfFStatistic.js
@@ -55,6 +55,7 @@ export default function DistributionOfFStatistic({ populations }) {
           title="Distribution of F-Statistic"
           xLabel="F-Statistic"
           yLabel="Observations of F-Statistic"
+          xMin={0}
         />
       )}
       </Alert>

--- a/src/components/ANOVA/FTest.js
+++ b/src/components/ANOVA/FTest.js
@@ -21,7 +21,7 @@ export default function FTest({ populations }) {
   const SSTR = sum(samples.map((sample) => sample.length * (((sample.length > 0) ? mean(sample) : 0) - overallSampleMean) ** 2));
   const MSTR = SSTR / (populations.length - 1);
   const SSE = sum(samples.map((sample) => (sample.length - 1) * ((sample.length > 0) ? std(sample) : 0) ** 2));
-  const MSE = SSE / (sum(populations.map(({ data }) => data.length)) - populations.length);
+  const MSE = SSE / (sum(samples.map((sample) => sample.length)) - populations.length);
   const F = MSTR / MSE;
   const pValue = jStat.anovaftest(...samples);
 

--- a/src/components/ANOVA/FTest.js
+++ b/src/components/ANOVA/FTest.js
@@ -7,6 +7,7 @@ import { populationMean, populationStandardDev } from '../../lib/stats-utils';
 import { jStat } from 'jstat';
 import PropTypes from 'prop-types';
 import { anovaObjectType } from '../../lib/types';
+import SimulateType1Error from './SimulateType1Error';
 
 export default function FTest({ populations }) {
   const [showResults, setShowResults] = useState(false);
@@ -73,6 +74,8 @@ export default function FTest({ populations }) {
               </tr>
             </tbody>
           </Table>
+          <hr/>
+          <SimulateType1Error/>
         </>
       )}
     </>

--- a/src/components/ANOVA/FTest.js
+++ b/src/components/ANOVA/FTest.js
@@ -6,7 +6,7 @@ import { mean, sum } from 'mathjs';
 import { populationMean, populationStandardDev } from '../../lib/stats-utils';
 import { jStat } from 'jstat';
 import PropTypes from 'prop-types';
-import { anovaObjectType } from '../../lib/types';
+import { anovaPopulationObjectType } from '../../lib/types';
 import SimulateType1Error from './SimulateType1Error';
 
 export default function FTest({ populations }) {
@@ -83,5 +83,5 @@ export default function FTest({ populations }) {
 }
 
 FTest.propTypes = {
-  populations: PropTypes.arrayOf(anovaObjectType).isRequired
+  populations: PropTypes.arrayOf(anovaPopulationObjectType).isRequired
 }

--- a/src/components/ANOVA/FTest.js
+++ b/src/components/ANOVA/FTest.js
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, Table } from 'react-bootstrap';
 import _ from 'lodash';
 import { BlockMath } from 'react-katex';
-import { mean, sum } from 'mathjs';
-import { populationMean, populationStandardDev } from '../../lib/stats-utils';
+import { mean, std, sum } from 'mathjs';
 import { jStat } from 'jstat';
 import PropTypes from 'prop-types';
 import { anovaPopulationObjectType } from '../../lib/types';
@@ -19,9 +18,9 @@ export default function FTest({ populations }) {
   const samples = populations.map(({ sample }) => sample.map(({ x }) => x));
 
   const overallSampleMean = (_.flatten(samples).length > 0) ? mean(_.flatten(samples)) : undefined;
-  const SSTR = sum(populations.map(({ data }) => data.length * (populationMean(data) - overallSampleMean) ** 2));
+  const SSTR = sum(samples.map((sample) => sample.length * (((sample.length > 0) ? mean(sample) : 0) - overallSampleMean) ** 2));
   const MSTR = SSTR / (populations.length - 1);
-  const SSE = sum(populations.map(({ data }) => (data.length - 1) * populationStandardDev(data) ** 2));
+  const SSE = sum(samples.map((sample) => (sample.length - 1) * ((sample.length > 0) ? std(sample) : 0) ** 2));
   const MSE = SSE / (sum(populations.map(({ data }) => data.length)) - populations.length);
   const F = MSTR / MSE;
   const pValue = jStat.anovaftest(...samples);

--- a/src/components/ANOVA/PopulationSettings.js
+++ b/src/components/ANOVA/PopulationSettings.js
@@ -6,7 +6,7 @@ import { Button, ButtonGroup, Col, Row } from 'react-bootstrap';
 import { generateNormal, getCounts } from '../../lib/stats-utils';
 import PropTypes from 'prop-types';
 import PopulationSampleSizeInput from './PopulationSampleSizeInput';
-import { anovaObjectType } from '../../lib/types.js';
+import { anovaPopulationObjectType } from '../../lib/types.js';
 import { randomInt } from 'mathjs';
 
 export default function PopulationSettings({ populations, setPopulations, setShowFTest }) {
@@ -110,7 +110,7 @@ export default function PopulationSettings({ populations, setPopulations, setSho
 }
 
 PopulationSettings.propTypes = {
-  populations: PropTypes.arrayOf(anovaObjectType).isRequired,
+  populations: PropTypes.arrayOf(anovaPopulationObjectType).isRequired,
   setPopulations: PropTypes.func.isRequired,
   setShowFTest: PropTypes.func.isRequired
 }

--- a/src/components/ANOVA/PopulationSettings.js
+++ b/src/components/ANOVA/PopulationSettings.js
@@ -61,7 +61,7 @@ export default function PopulationSettings({ populations, setPopulations, setSho
 
   const generatePopulations = () => {
     setPopulations(populations.map((pop) => {
-      const data = getCounts(generateNormal(500, pop.mean, stdDev, 0));
+      const data = getCounts(generateNormal(500, pop.mean, stdDev, 1));
       return { ...pop, data, sample: [] }
     }));
     setShowFTest(true);

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -1,32 +1,11 @@
-import _ from 'lodash';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from 'react-bootstrap';
-import { InlineMath } from 'react-katex';
-import { generateNormal, getCounts } from '../../lib/stats-utils';
-import LabeledInput from '../LabeledInput';
-import LabeledSelector from '../LabeledSelector';
 import SimulationPopulationsDisplay from './SimulationPopulationsDisplay';
+import SimulationPopulationSettings from './SimulationPopulationSettings';
 
 export default function SimulateType1Error() {
   const [showSim, setShowSim] = useState(false);
-  const [numPops, setNumPops] = useState(2);
-  const [alpha, setAlpha] = useState(0.05);
-  const [mean, setMean] = useState(0);
-  const [stdDev, setStdDev] = useState(3);
   const [populations, setPopulations] = useState([]);
-
-  useEffect(() => {
-    setPopulations([]);
-  }, [numPops, alpha, mean, stdDev]);
-
-  const generatePopulations = () => {
-    const newPopulations = _.range(1, numPops + 1).map((id) => ({
-      data: getCounts(generateNormal(500, mean, stdDev, 0)),
-      id,
-      sampleSize: 30
-    }));
-    setPopulations(newPopulations);
-  }
 
   return (
     <>
@@ -41,24 +20,7 @@ export default function SimulateType1Error() {
       <br/>
       {showSim && (
         <>
-          <LabeledSelector min={2} max={20} label="Number of populations:" value={numPops} setValue={setNumPops}/>
-          <br/>
-          <LabeledInput min={0} max={1} step={0.01} label={<>Tolerance <InlineMath math="\alpha"/>:</>} value={alpha} setValue={setAlpha}/>
-          <br/>
-          <p>
-            The null hypothesis <InlineMath math="H_0"/> is that <InlineMath math={`\\mu_1 = \\mu_2 ${(numPops > 3) ? '= \\dotsc' : ''} ${(numPops > 2) ? `= \\mu_{${numPops}}` : ''}`}/>.
-          </p>
-          <LabeledSelector min={-5} max={5} label="Set mean of all populations:" value={mean} setValue={setMean}/>
-          <br/>
-          <LabeledSelector min={1} max={4} label="Set the standard deviations:" value={stdDev} setValue={setStdDev}/>
-          <br/>
-          <Button
-            active={(populations.length > 0)}
-            variant="outline-primary"
-            onClick={() => generatePopulations()}
-          >
-            Generate Populations
-          </Button>
+          <SimulationPopulationSettings activeButton={populations.length > 0} setPopulations={setPopulations}/>
           <br/>
           <br/>
           {(populations.length > 0) && <SimulationPopulationsDisplay populations={populations}/>}

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -8,6 +8,7 @@ import SimulationSampleSettings from './SimulationSampleSettings';
 export default function SimulateType1Error() {
   const [showSim, setShowSim] = useState(false);
   const [populations, setPopulations] = useState([]);
+  const [alpha, setAlpha] = useState(0.05);
 
   return (
     <>
@@ -22,7 +23,12 @@ export default function SimulateType1Error() {
       <br/>
       {showSim && (
         <>
-          <SimulationPopulationSettings activeButton={populations.length > 0} setPopulations={setPopulations}/>
+          <SimulationPopulationSettings
+            activeButton={populations.length > 0}
+            setPopulations={setPopulations}
+            alpha={alpha}
+            setAlpha={setAlpha}
+          />
           <br/>
           <br/>
           {(populations.length > 0) && (
@@ -31,7 +37,7 @@ export default function SimulateType1Error() {
               <br/>
               <SimulationSampleSettings populations={populations} setPopulations={setPopulations}/>
               <br/>
-              <DistributionOfFStatistic populations={populations}/>
+              <DistributionOfFStatistic populations={populations} alpha={alpha}/>
             </>
           )}
         </>

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -1,0 +1,69 @@
+import _ from 'lodash';
+import { useEffect, useState } from 'react';
+import { Button } from 'react-bootstrap';
+import { InlineMath } from 'react-katex';
+import { generateNormal, getCounts } from '../../lib/stats-utils';
+import LabeledInput from '../LabeledInput';
+import LabeledSelector from '../LabeledSelector';
+import SimulationPopulationsDisplay from './SimulationPopulationsDisplay';
+
+export default function SimulateType1Error() {
+  const [showSim, setShowSim] = useState(false);
+  const [numPops, setNumPops] = useState(2);
+  const [alpha, setAlpha] = useState(0.05);
+  const [mean, setMean] = useState(0);
+  const [stdDev, setStdDev] = useState(3);
+  const [populations, setPopulations] = useState([]);
+
+  useEffect(() => {
+    setPopulations([]);
+  }, [numPops, alpha, mean, stdDev]);
+
+  const generatePopulations = () => {
+    const newPopulations = _.range(1, numPops + 1).map((id) => ({
+      data: getCounts(generateNormal(500, mean, stdDev, 0)),
+      id,
+      sampleSize: 30
+    }));
+    setPopulations(newPopulations);
+  }
+
+  return (
+    <>
+      <Button
+        active={showSim}
+        variant="outline-primary"
+        onClick={() => setShowSim(true)}
+      >
+        Simulate Type I Error for ANOVA
+      </Button>
+      <br/>
+      <br/>
+      {showSim && (
+        <>
+          <LabeledSelector min={2} max={20} label="Number of populations:" value={numPops} setValue={setNumPops}/>
+          <br/>
+          <LabeledInput min={0} max={1} step={0.01} label={<>Tolerance <InlineMath math="\alpha"/>:</>} value={alpha} setValue={setAlpha}/>
+          <br/>
+          <p>
+            The null hypothesis <InlineMath math="H_0"/> is that <InlineMath math={`\\mu_1 = \\mu_2 ${(numPops > 3) ? '= \\dotsc' : ''} ${(numPops > 2) ? `= \\mu_{${numPops}}` : ''}`}/>.
+          </p>
+          <LabeledSelector min={-5} max={5} label="Set mean of all populations:" value={mean} setValue={setMean}/>
+          <br/>
+          <LabeledSelector min={1} max={4} label="Set the standard deviations:" value={stdDev} setValue={setStdDev}/>
+          <br/>
+          <Button
+            active={(populations.length > 0)}
+            variant="outline-primary"
+            onClick={() => generatePopulations()}
+          >
+            Generate Populations
+          </Button>
+          <br/>
+          <br/>
+          {(populations.length > 0) && <SimulationPopulationsDisplay populations={populations}/>}
+        </>
+      )}
+    </>
+  )
+}

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Button } from 'react-bootstrap';
+import DistributionOfFStatistic from './DistributionOfFStatistic';
 import SimulationPopulationsDisplay from './SimulationPopulationsDisplay';
 import SimulationPopulationSettings from './SimulationPopulationSettings';
 import SimulationSampleSettings from './SimulationSampleSettings';
@@ -29,6 +30,8 @@ export default function SimulateType1Error() {
               <SimulationPopulationsDisplay populations={populations}/>
               <br/>
               <SimulationSampleSettings populations={populations} setPopulations={setPopulations}/>
+              <br/>
+              <DistributionOfFStatistic populations={populations}/>
             </>
           )}
         </>

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -24,7 +24,6 @@ export default function SimulateType1Error() {
       {showSim && (
         <>
           <SimulationPopulationSettings
-            activeButton={populations.length > 0}
             setPopulations={setPopulations}
             alpha={alpha}
             setAlpha={setAlpha}

--- a/src/components/ANOVA/SimulateType1Error.js
+++ b/src/components/ANOVA/SimulateType1Error.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import SimulationPopulationsDisplay from './SimulationPopulationsDisplay';
 import SimulationPopulationSettings from './SimulationPopulationSettings';
+import SimulationSampleSettings from './SimulationSampleSettings';
 
 export default function SimulateType1Error() {
   const [showSim, setShowSim] = useState(false);
@@ -23,7 +24,13 @@ export default function SimulateType1Error() {
           <SimulationPopulationSettings activeButton={populations.length > 0} setPopulations={setPopulations}/>
           <br/>
           <br/>
-          {(populations.length > 0) && <SimulationPopulationsDisplay populations={populations}/>}
+          {(populations.length > 0) && (
+            <>
+              <SimulationPopulationsDisplay populations={populations}/>
+              <br/>
+              <SimulationSampleSettings populations={populations} setPopulations={setPopulations}/>
+            </>
+          )}
         </>
       )}
     </>

--- a/src/components/ANOVA/SimulationPopulationSettings.js
+++ b/src/components/ANOVA/SimulationPopulationSettings.js
@@ -19,7 +19,7 @@ export default function SimulationPopulationSettings({ setPopulations, alpha, se
 
   const generatePopulations = () => {
     const newPopulations = _.range(1, numPops + 1).map((id) => ({
-      data: getCounts(generateNormal(500, mean, stdDev, 0)),
+      data: getCounts(generateNormal(500, mean, stdDev, 1)),
       id,
       sampleSize: 30
     }));

--- a/src/components/ANOVA/SimulationPopulationSettings.js
+++ b/src/components/ANOVA/SimulationPopulationSettings.js
@@ -6,6 +6,7 @@ import { generateNormal, getCounts } from '../../lib/stats-utils';
 import LabeledInput from '../LabeledInput';
 import LabeledSelector from '../LabeledSelector';
 import PropTypes from 'prop-types';
+import { stringOrNumberType } from '../../lib/types';
 
 export default function SimulationPopulationSettings({ setPopulations, alpha, setAlpha }) {
   const [numPops, setNumPops] = useState(2);
@@ -57,6 +58,6 @@ export default function SimulationPopulationSettings({ setPopulations, alpha, se
 
 SimulationPopulationSettings.propTypes = {
   setPopulations: PropTypes.func.isRequired,
-  alpha: PropTypes.number.isRequired,
+  alpha: stringOrNumberType.isRequired,
   setAlpha: PropTypes.func.isRequired
 }

--- a/src/components/ANOVA/SimulationPopulationSettings.js
+++ b/src/components/ANOVA/SimulationPopulationSettings.js
@@ -7,9 +7,8 @@ import LabeledInput from '../LabeledInput';
 import LabeledSelector from '../LabeledSelector';
 import PropTypes from 'prop-types';
 
-export default function SimulationPopulationSettings({ activeButton, setPopulations }) {
+export default function SimulationPopulationSettings({ activeButton, setPopulations, alpha, setAlpha }) {
   const [numPops, setNumPops] = useState(2);
-  const [alpha, setAlpha] = useState(0.05);
   const [mean, setMean] = useState(0);
   const [stdDev, setStdDev] = useState(3);
 
@@ -59,5 +58,7 @@ export default function SimulationPopulationSettings({ activeButton, setPopulati
 
 SimulationPopulationSettings.propTypes = {
   activeButton: PropTypes.bool.isRequired,
-  setPopulations: PropTypes.func.isRequired
+  setPopulations: PropTypes.func.isRequired,
+  alpha: PropTypes.number.isRequired,
+  setAlpha: PropTypes.func.isRequired
 }

--- a/src/components/ANOVA/SimulationPopulationSettings.js
+++ b/src/components/ANOVA/SimulationPopulationSettings.js
@@ -1,0 +1,63 @@
+import _ from 'lodash';
+import { useEffect, useState } from 'react';
+import { Button } from 'react-bootstrap';
+import { InlineMath } from 'react-katex';
+import { generateNormal, getCounts } from '../../lib/stats-utils';
+import LabeledInput from '../LabeledInput';
+import LabeledSelector from '../LabeledSelector';
+import PropTypes from 'prop-types';
+
+export default function SimulationPopulationSettings({ activeButton, setPopulations }) {
+  const [numPops, setNumPops] = useState(2);
+  const [alpha, setAlpha] = useState(0.05);
+  const [mean, setMean] = useState(0);
+  const [stdDev, setStdDev] = useState(3);
+
+  useEffect(() => {
+    setPopulations([]);
+  }, [numPops, alpha, mean, stdDev, setPopulations]);
+
+  const generatePopulations = () => {
+    const newPopulations = _.range(1, numPops + 1).map((id) => ({
+      data: getCounts(generateNormal(500, mean, stdDev, 0)),
+      id,
+      sampleSize: 30
+    }));
+    setPopulations(newPopulations);
+  }
+
+  return (
+    <>
+      <LabeledSelector min={2} max={20} label="Number of populations:" value={numPops} setValue={setNumPops}/>
+      <br/>
+      <LabeledInput
+        min={0}
+        max={1}
+        step={0.01}
+        label={<>Tolerance <InlineMath math="\alpha"/>:</>}
+        value={alpha}
+        setValue={setAlpha}
+      />
+      <br/>
+      <p>
+        The null hypothesis <InlineMath math="H_0"/> is that <InlineMath math={`\\mu_1 = \\mu_2 ${(numPops > 3) ? '= \\dotsc' : ''} ${(numPops > 2) ? `= \\mu_{${numPops}}` : ''}`}/>.
+      </p>
+      <LabeledSelector min={-5} max={5} label="Set mean of all populations:" value={mean} setValue={setMean}/>
+      <br/>
+      <LabeledSelector min={1} max={4} label="Set the standard deviations:" value={stdDev} setValue={setStdDev}/>
+      <br/>
+      <Button
+        active={activeButton}
+        variant="outline-primary"
+        onClick={() => generatePopulations()}
+      >
+        Generate Populations
+      </Button>
+    </>
+  )
+}
+
+SimulationPopulationSettings.propTypes = {
+  activeButton: PropTypes.bool.isRequired,
+  setPopulations: PropTypes.func.isRequired
+}

--- a/src/components/ANOVA/SimulationPopulationSettings.js
+++ b/src/components/ANOVA/SimulationPopulationSettings.js
@@ -7,7 +7,7 @@ import LabeledInput from '../LabeledInput';
 import LabeledSelector from '../LabeledSelector';
 import PropTypes from 'prop-types';
 
-export default function SimulationPopulationSettings({ activeButton, setPopulations, alpha, setAlpha }) {
+export default function SimulationPopulationSettings({ setPopulations, alpha, setAlpha }) {
   const [numPops, setNumPops] = useState(2);
   const [mean, setMean] = useState(0);
   const [stdDev, setStdDev] = useState(3);
@@ -46,7 +46,6 @@ export default function SimulationPopulationSettings({ activeButton, setPopulati
       <LabeledSelector min={1} max={4} label="Set the standard deviations:" value={stdDev} setValue={setStdDev}/>
       <br/>
       <Button
-        active={activeButton}
         variant="outline-primary"
         onClick={() => generatePopulations()}
       >
@@ -57,7 +56,6 @@ export default function SimulationPopulationSettings({ activeButton, setPopulati
 }
 
 SimulationPopulationSettings.propTypes = {
-  activeButton: PropTypes.bool.isRequired,
   setPopulations: PropTypes.func.isRequired,
   alpha: PropTypes.number.isRequired,
   setAlpha: PropTypes.func.isRequired

--- a/src/components/ANOVA/SimulationPopulationsDisplay.js
+++ b/src/components/ANOVA/SimulationPopulationsDisplay.js
@@ -2,7 +2,7 @@ import { min } from 'mathjs';
 import { Col, Row } from 'react-bootstrap';
 import DotPlot from '../DotPlot';
 import PropTypes from 'prop-types';
-import { dataObjectArrayType } from '../../lib/types';
+import { anovaPopulationObjectType } from '../../lib/types';
 
 export default function SimulationPopulationsDisplay({ populations }) {
   return (
@@ -24,11 +24,5 @@ export default function SimulationPopulationsDisplay({ populations }) {
 }
 
 SimulationPopulationsDisplay.propTypes = {
-  populations: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      data: dataObjectArrayType.isRequired,
-      sampleSize: PropTypes.number.isRequired
-    })
-  ).isRequired
+  populations: PropTypes.arrayOf(anovaPopulationObjectType).isRequired
 }

--- a/src/components/ANOVA/SimulationPopulationsDisplay.js
+++ b/src/components/ANOVA/SimulationPopulationsDisplay.js
@@ -1,0 +1,34 @@
+import { min } from 'mathjs';
+import { Col, Row } from 'react-bootstrap';
+import DotPlot from '../DotPlot';
+import PropTypes from 'prop-types';
+import { dataObjectArrayType } from '../../lib/types';
+
+export default function SimulationPopulationsDisplay({ populations }) {
+  return (
+    <Row xs={1} sm={2} md={min(populations.length, 4)}>
+      {populations.map(({ id, data }) => (
+        <Col key={id}>
+          <DotPlot
+            series={[{ name: 'Population Observations', data, showInLegend: false }]}
+            title={`Population ${id}`}
+            xMin={-20}
+            xMax={20}
+            xLabel="Value"
+            yLabel="Observations"
+          />
+        </Col>
+      ))}
+    </Row>
+  )
+}
+
+SimulationPopulationsDisplay.propTypes = {
+  populations: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      data: dataObjectArrayType.isRequired,
+      sampleSize: PropTypes.number.isRequired
+    })
+  ).isRequired
+}

--- a/src/components/ANOVA/SimulationSampleSettings.js
+++ b/src/components/ANOVA/SimulationSampleSettings.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { Row } from 'react-bootstrap';
+import { anovaPopulationObjectType } from '../../lib/types';
+import LabeledInput from '../LabeledInput';
+
+export default function SimulationSampleSettings({ populations, setPopulations }) {
+  const setSampleSize = (id, value) => {
+    const newPopulations = populations.map((pop) => ({
+      ...pop,
+      sampleSize: (pop.id === id) ? value : pop.sampleSize
+    }));
+    setPopulations(newPopulations);
+  }
+
+  return (
+    <>
+      {populations.map(({ sampleSize, id }) => (
+        <Row key={id}>
+          <LabeledInput
+            min={1}
+            max={500}
+            label={`Set sample size for Population ${id}: `}
+            value={sampleSize}
+            setValue={(val) => setSampleSize(id, val)}/>
+        </Row>
+      ))}
+    </>
+  )
+}
+
+SimulationSampleSettings.propTypes = {
+  populations: PropTypes.arrayOf(anovaPopulationObjectType).isRequired,
+  setPopulations: PropTypes.func.isRequired
+}

--- a/src/components/CentralLimitTheorem/CentralLimitTheoremContainer.js
+++ b/src/components/CentralLimitTheorem/CentralLimitTheoremContainer.js
@@ -1,11 +1,5 @@
-/*
-
-  Displays the description for the CLT simulation, a menu bar to choose the different variations, and the simulation component itself
-
-*/
 import { useState } from 'react';
 import PopBar from '../PopBar.js';
-import { Alert } from 'react-bootstrap';
 import CentralLimitTheorem from './CentralLimitTheorem.js';
 import SimulationIntro from '../SimulationIntro.js';
 

--- a/src/components/ConfidenceIntervals/ConfidenceIntervalsContainer.js
+++ b/src/components/ConfidenceIntervals/ConfidenceIntervalsContainer.js
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import PopBar from '../PopBar.js';
-import { Alert } from 'react-bootstrap';
 import ConfidenceIntervals from './ConfidenceIntervals.js';
 import { SAMPLE_SIZE } from '../../lib/constants.js';
 import SimulationIntro from '../SimulationIntro.js';

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -13,7 +13,8 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel, yLabe
     const newChart = {
       chart: {
         type: 'scatter',
-        animation: !!animation
+        animation: !!animation,
+        zoomType: zoom && 'xy'
       },
       plotOptions: {
         series: {

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -58,7 +58,8 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel, yLabe
           tooltip: {
             pointFormat: `${xLabel}: <b>{point.x}</b><br />`
           },
-          ...seriesObject
+          ...seriesObject,
+          data: seriesObject.data.map(({ x, y }) => ({ x, y }))
         })
       )
     }

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -59,7 +59,7 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel, yLabe
             pointFormat: `${xLabel}: <b>{point.x}</b><br />`
           },
           ...seriesObject,
-          data: seriesObject.data.map(({ x, y }) => ({ x, y }))
+          data: seriesObject.data.map(({ x, y }) => ({ x, y }))  // don't want any other attributes
         })
       )
     }

--- a/src/components/DotPlot.js
+++ b/src/components/DotPlot.js
@@ -54,11 +54,10 @@ export default function DotPlot({ series, title, xMin, xMax, yMax, xLabel, yLabe
         {
           showInLegend: seriesObject.data.length > 0,
           turboThreshold: 0,
-          ...seriesObject,
-          data: seriesObject.data.map(({ x, y }) => ({ x, y })), // don't want any other attributes
           tooltip: {
             pointFormat: `${xLabel}: <b>{point.x}</b><br />`
-          }
+          },
+          ...seriesObject
         })
       )
     }

--- a/src/components/HypothesisTesting/HypothesisTestingContainer.js
+++ b/src/components/HypothesisTesting/HypothesisTestingContainer.js
@@ -1,4 +1,3 @@
-import { Alert } from 'react-bootstrap';
 import SimulationIntro from '../SimulationIntro.js';
 import HypothesisTesting from './HypothesisTesting.js';
 

--- a/src/components/HypothesisTesting/SimulateTypeOneError.js
+++ b/src/components/HypothesisTesting/SimulateTypeOneError.js
@@ -125,7 +125,6 @@ export default function SimulateTypeOneError({ popShape, mu0, alpha, distType, s
         <Col>
           {!standardized ? (
             <NormalCurve
-              meansDiff={sampleMeans.mean}
               means={sampleMeans}
               mu0={mu0}
               popStandardDev={_.defaultTo(populationStandardDev(population), 0)}

--- a/src/components/JointDistributions/JointDistributionsContainer.js
+++ b/src/components/JointDistributions/JointDistributionsContainer.js
@@ -1,9 +1,3 @@
-/*
-
-  A container component that holds the description and simulation for Joint Distribution
-
-*/
-import { Alert } from 'react-bootstrap';
 import SimulationIntro from '../SimulationIntro.js';
 import JointDistributions from './JointDistributions.js';
 

--- a/src/components/LabeledInput.js
+++ b/src/components/LabeledInput.js
@@ -1,6 +1,6 @@
 import { Form, Col, Row } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import { stringOrNumberType } from '../lib/types';
+import { optionalLaTeXType, stringOrNumberType } from '../lib/types';
 
 export default function LabeledInput({ min, max, step, label, value, setValue }) {
   return (
@@ -27,7 +27,7 @@ LabeledInput.propTypes = {
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
   step: PropTypes.number,
-  label: PropTypes.string.isRequired,
+  label: optionalLaTeXType.isRequired,
   value: stringOrNumberType.isRequired,
   setValue: PropTypes.func.isRequired
 }

--- a/src/components/LabeledInput.js
+++ b/src/components/LabeledInput.js
@@ -2,7 +2,7 @@ import { Form, Col, Row } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { stringOrNumberType } from '../lib/types';
 
-export default function LabeledInput({ min, max, label, value, setValue }) {
+export default function LabeledInput({ min, max, step, label, value, setValue }) {
   return (
     <Form>
       <Form.Group as={Row} className="justify-content-md-center">
@@ -13,6 +13,7 @@ export default function LabeledInput({ min, max, label, value, setValue }) {
             type="number"
             min={min}
             max={max}
+            step={step || 1}
             value={value}
             onChange={(event) => setValue(event.target.value)}
           />
@@ -25,6 +26,7 @@ export default function LabeledInput({ min, max, label, value, setValue }) {
 LabeledInput.propTypes = {
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
+  step: PropTypes.number,
   label: PropTypes.string.isRequired,
   value: stringOrNumberType.isRequired,
   setValue: PropTypes.func.isRequired

--- a/src/components/LawOfLargeNumbers/LawOfLargeNumbersContainer.js
+++ b/src/components/LawOfLargeNumbers/LawOfLargeNumbersContainer.js
@@ -1,11 +1,5 @@
-/*
-
-  Displays the description for the LLN simulation, a menu bar to choose the different variations, and the simulation component itself
-
-*/
 import { useState } from 'react';
 import PopBar from '../PopBar.js';
-import { Alert } from 'react-bootstrap';
 import LawOfLargeNumbers from './LawOfLargeNumbers.js';
 import { SAMPLE_SIZE } from '../../lib/constants.js';
 import SimulationIntro from '../SimulationIntro.js';

--- a/src/components/LeastSquares/LeastSquaresContainer.js
+++ b/src/components/LeastSquares/LeastSquaresContainer.js
@@ -1,5 +1,4 @@
 import LeastSquares from './LeastSquares';
-import { Alert } from 'react-bootstrap';
 import SimulationIntro from '../SimulationIntro';
 
 export default function LeastSquaresContainer() {

--- a/src/components/MultipleRegression/MultipleRegressionContainer.js
+++ b/src/components/MultipleRegression/MultipleRegressionContainer.js
@@ -1,4 +1,3 @@
-import { Alert } from 'react-bootstrap';
 import SimulationIntro from '../SimulationIntro';
 import MultipleRegression from './MultipleRegression';
 

--- a/src/components/OLSEstimatorsAreConsistent/OLSEstimatorsAreConsistentContainer.js
+++ b/src/components/OLSEstimatorsAreConsistent/OLSEstimatorsAreConsistentContainer.js
@@ -1,4 +1,3 @@
-import { Alert } from 'react-bootstrap';
 import OLSEstimatorsAreConsistent from './OLSEstimatorsAreConsistent.js';
 import SelectorButtonGroup from '../SelectorButtonGroup.js';
 import { useState } from 'react';

--- a/src/components/OmittedVariableBias/OmittedVariableBiasContainer.js
+++ b/src/components/OmittedVariableBias/OmittedVariableBiasContainer.js
@@ -1,4 +1,4 @@
-import { Alert, Row } from 'react-bootstrap';
+import { Row } from 'react-bootstrap';
 import OmittedVariableBias from './OmittedVariableBias';
 import { InlineMath } from 'react-katex';
 import SimulationIntro from '../SimulationIntro';

--- a/src/components/SampleDistributionOLSEstimators/SampleDistributionOLSEstimatorsContainer.js
+++ b/src/components/SampleDistributionOLSEstimators/SampleDistributionOLSEstimatorsContainer.js
@@ -1,4 +1,3 @@
-import { Alert } from 'react-bootstrap';
 import SampleDistributionOLSEstimators from './SampleDistributionOLSEstimators.js';
 import SelectorButtonGroup from '../SelectorButtonGroup.js';
 import { useState } from 'react';

--- a/src/components/SimulationIntro.js
+++ b/src/components/SimulationIntro.js
@@ -14,5 +14,5 @@ export default function SimulationIntro({ name, text }) {
 
 SimulationIntro.propTypes = {
   name: PropTypes.string.isRequired,
-  text: PropTypes.oneOfType(optionalLaTeXType).isRequired
+  text: optionalLaTeXType.isRequired
 }

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -75,10 +75,10 @@ export const hypothesisEqualityType = PropTypes.oneOf(['<', '>', '!=']);
 
 export const optionalLaTeXType = PropTypes.oneOfType([PropTypes.element, PropTypes.string]);
 
-export const anovaObjectType = PropTypes.shape({
+export const anovaPopulationObjectType = PropTypes.shape({
   id: PropTypes.number.isRequired,
-  mean: PropTypes.number.isRequired,
+  mean: PropTypes.number,
   sampleSize: stringOrNumberType.isRequired,
   data: dataObjectArrayType.isRequired,
-  sample: dataObjectArrayType.isRequired
+  sample: dataObjectArrayType
 });


### PR DESCRIPTION
Populations can now be generated and f-stats are plotted.

How do we want to represent rejecting/accepting? Similar to hypothesis testing where the points are red/green? 

What information should we include in the tooltip for each point? I'm thinking f-stat, pval, reject/accept at least.

Still need to add summary text.