### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      - dependency-name: "@nivo/core"
+      - dependency-name: "@nivo/scatterplot"
       
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "prettier": "^2.3.2"
       },
       "engines": {
-        "node": "12.18.x"
+        "node": "14.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://professoramanda.github.io/econsimulations",
   "license": "Apache-2.0",
   "engines": {
-    "node": "12.18.x"
+    "node": "14.x"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
This is something that I intended to set up a while ago but forgot. Dependabot will automatically check for outdated packages and submit pull requests to update them. Currently it's set up to check every Monday.

Note: Currently I've set this up to ignore updates from the `nivo` package, which we use for the Joint Distributions graphs. This is because the most recent update breaks the synchronization of the plots we currently have.