### PR TITLE
show regression equation

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ESLINT_NO_DEV_ERRORS=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "highcharts": "^9.2.2",
         "highcharts-react-official": "^3.0.0",
         "jstat": "^1.9.5",
+        "katex": "^0.16.0",
         "lodash": "^4.17.21",
         "mathjs": "^9.4.4",
         "multivariate-normal": "^0.1.2",
@@ -13307,14 +13308,26 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
-      "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.0.tgz",
+      "integrity": "sha512-wPRB4iUPysfH97wTgG5/tRLYxmKVq6Q4jRAWRVOUxXB1dsiv4cvcNjqabHkrOvJHM1Bpk3WrgmllSO1vIvP24w==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
       "dependencies": {
-        "match-at": "^0.1.1"
+        "commander": "^8.0.0"
       },
       "bin": {
         "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/kdbush": {
@@ -17630,6 +17643,17 @@
       "peerDependencies": {
         "prop-types": "^15.5.10",
         "react": "^15.3.2 || ^16.0.0"
+      }
+    },
+    "node_modules/react-katex/node_modules/katex": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
+      "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+      "dependencies": {
+        "match-at": "^0.1.1"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/react-lifecycles-compat": {
@@ -25045,8 +25069,7 @@
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "requires": {}
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -25139,8 +25162,7 @@
     "@nivo/legends": {
       "version": "0.70.1",
       "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.70.1.tgz",
-      "integrity": "sha512-a+syic9S/PcnnGgeNCjgxgdnsXJ6tXEDrk+rTpOgFVRHBlqVa1TPT+HUGaDixqLv458RoVIbZmsr2RPTHvFF7Q==",
-      "requires": {}
+      "integrity": "sha512-a+syic9S/PcnnGgeNCjgxgdnsXJ6tXEDrk+rTpOgFVRHBlqVa1TPT+HUGaDixqLv458RoVIbZmsr2RPTHvFF7Q=="
     },
     "@nivo/recompose": {
       "version": "0.70.0",
@@ -25371,8 +25393,7 @@
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
-      "requires": {}
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
     },
     "@restart/hooks": {
       "version": "0.3.27",
@@ -26342,8 +26363,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -26395,14 +26415,12 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "requires": {}
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "almost-equal": {
       "version": "1.1.0",
@@ -26999,8 +27017,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
-      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
-      "requires": {}
+      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.2",
@@ -27459,8 +27476,7 @@
     "bootstrap": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "requires": {}
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -30245,8 +30261,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "requires": {}
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",
@@ -31765,8 +31780,7 @@
     "highcharts-react-official": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.0.0.tgz",
-      "integrity": "sha512-VefJgDY2hkT9gfppsQGrRF2g5u8d9dtfHGcx2/xqiP+PkZXCqalw9xOeKVCRvJKTOh0coiDFwvVjOvB7KaGl4A==",
-      "requires": {}
+      "integrity": "sha512-VefJgDY2hkT9gfppsQGrRF2g5u8d9dtfHGcx2/xqiP+PkZXCqalw9xOeKVCRvJKTOh0coiDFwvVjOvB7KaGl4A=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -33153,8 +33167,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -33750,11 +33763,18 @@
       }
     },
     "katex": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
-      "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.0.tgz",
+      "integrity": "sha512-wPRB4iUPysfH97wTgG5/tRLYxmKVq6Q4jRAWRVOUxXB1dsiv4cvcNjqabHkrOvJHM1Bpk3WrgmllSO1vIvP24w==",
       "requires": {
-        "match-at": "^0.1.1"
+        "commander": "^8.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
       }
     },
     "kdbush": {
@@ -36987,8 +37007,7 @@
     "react-collapse": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.0.tgz",
-      "integrity": "sha512-5v0ywsn9HjiR/odNzbRDs0RZfrnbdSippJebWOBCFFDA12Vx8DddrbI4qWVf1P2wTiVagrpcSy07AU0b6+gM9Q==",
-      "requires": {}
+      "integrity": "sha512-5v0ywsn9HjiR/odNzbRDs0RZfrnbdSippJebWOBCFFDA12Vx8DddrbI4qWVf1P2wTiVagrpcSy07AU0b6+gM9Q=="
     },
     "react-dev-utils": {
       "version": "11.0.4",
@@ -37213,6 +37232,16 @@
       "integrity": "sha512-mk1ezfUF4mBIstjvpfELf9g1rWF1Y1+idXMiOvkFvCLi0JFZDCQdui59VqQcI2ynOpb0jj52TM4kyBjKG+qEBg==",
       "requires": {
         "katex": "^0.9.0"
+      },
+      "dependencies": {
+        "katex": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
+          "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+          "requires": {
+            "match-at": "^0.1.1"
+          }
+        }
       }
     },
     "react-lifecycles-compat": {
@@ -41739,8 +41768,7 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "requires": {}
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "highcharts": "^9.2.2",
     "highcharts-react-official": "^3.0.0",
     "jstat": "^1.9.5",
+    "katex": "^0.16.0",
     "lodash": "^4.17.21",
     "mathjs": "^9.4.4",
     "multivariate-normal": "^0.1.2",

--- a/src/__tests__/FixedEffects.test.js
+++ b/src/__tests__/FixedEffects.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import FixedEffects from '../components/FixedEffects/FixedEffects';
 
 describe('FixedEffects integration tests', () => {

--- a/src/components/OmittedVariableBias/OmittedVariableBias.js
+++ b/src/components/OmittedVariableBias/OmittedVariableBias.js
@@ -8,6 +8,8 @@ import PD from 'probability-distributions';
 import _ from 'lodash';
 import InputSlider from '../InputSlider.js';
 import { linearRegression } from '../../lib/stats-utils.js';
+import { InlineMath, BlockMath } from 'react-katex';
+//import TeX from '@matejmazur/react-katex';
 
 export default function OmittedVariableBias() {
   const [beta, setBeta] = useState(3);
@@ -148,16 +150,15 @@ export default function OmittedVariableBias() {
               <div style={{
                 display: 'flex',
                 flexDirection: 'column',
-                justifyContent: 'center',
                 alignItems: 'flex-start',
                 marginTop: '20%'
               }}>
-                <p>
-                  {`Naive Regression: f(x) = ${naiveLine[0].toFixed(2)}x + ${naiveLine[1].toFixed(2)}`}
-                </p>
-                <p>
-                  {showCorrect ? `Corrected Regression: f(x) = ${correctedLine[0].toFixed(2)}x + ${correctedLine[1].toFixed(2)}` : ''}
-                </p>
+                <InlineMath>
+                  {`\\text{Naive Regression: }f(x) = ${naiveLine[0].toFixed(2)}x + ${naiveLine[1].toFixed(2)}`}
+                </InlineMath>
+                <InlineMath>
+                  {showCorrect ? `\\text{Corrected Regression: }f(x) = ${correctedLine[0].toFixed(2)}x + ${correctedLine[1].toFixed(2)}` : ''}
+                </InlineMath>
               </div>
             </Col>
           </Row>

--- a/src/components/OmittedVariableBias/OmittedVariableBias.js
+++ b/src/components/OmittedVariableBias/OmittedVariableBias.js
@@ -18,6 +18,9 @@ export default function OmittedVariableBias() {
   const [showCorrect, setShowCorrect] = useState(false);
   const [allData, setAllData] = useState({ points: [], naiveLine: [], correctedLine: [] });
 
+  const [naiveLine, setNaiveLine] = useState([0, 0]); // [slope, intercept]
+  const [correctedLine, setCorrectedLine] = useState([0, 0]); // [slope, intercept]
+
   const stdX = 3;
   const stdY = 6;
   const OBS = 1000;
@@ -63,6 +66,9 @@ export default function OmittedVariableBias() {
 
       const generatePoints = (slope, int) => _.range(0, 11).map((i) => _.round(int + i * slope, 2));
 
+      setNaiveLine([slope, intercept]);
+      setCorrectedLine([parseFloat(bHat.get([1, 0])), parseFloat(bHat.get([0, 0]))]);
+
       setAllData({
         points: studyScores.map(([x, y]) => ({ x, y })),
         naiveLine: generatePoints(slope, intercept),
@@ -104,15 +110,15 @@ export default function OmittedVariableBias() {
       <Row>
         <p>Choose Population Parameters:</p>
       </Row>
-      <br/>
+      <br />
       <Row lg={2} sm={1}>
         <Col style={{ margin: 'auto', padding: 10 }}>
-          <CoefficientInput beta={beta} setBeta={setBeta} delta={delta} setDelta={setDelta}/>
+          <CoefficientInput beta={beta} setBeta={setBeta} delta={delta} setDelta={setDelta} />
         </Col>
         <Col>
           <div style={{ padding: 10 }}>Set the Correlation between Study Hours and Sleep Hours:</div>
-          <InputSlider value={correlation} min={-0.99} max={0.99} step={0.01} onChange={(value) => setCorrelation(value)}/>
-          <br/>
+          <InputSlider value={correlation} min={-0.99} max={0.99} step={0.01} onChange={(value) => setCorrelation(value)} />
+          <br />
           <Alert variant="secondary" style={{ width: 'fit-content', margin: 'auto' }}>
             Covariance between Study Hours and Sleep Hours: {' '}
             <Badge className="badge bg-primary pill" aria-label="covariance">{(correlation * stdX * stdY).toFixed(2)}</Badge>
@@ -120,23 +126,39 @@ export default function OmittedVariableBias() {
 
         </Col>
       </Row>
-      <br/>
+      <br />
       <Row>
         <Col>
           <p>Estimate Regression Using Test Score and Study Hours Data </p>
           <Button variant="primary" onClick={() => generateSeries()}>Generate!</Button>
         </Col>
       </Row>
-      <br/>
+      <br />
       {(stage >= 2) && (
         <div>
           <Row>
-            <Col lg={{ span: 12, offset: 0 }} xl={{ span: 8, offset: 2 }}>
+            <Col lg={{ span: 12, offset: 0 }} xl={{ span: 8, offset: 0 }}>
               <OmittedVariableChart
                 dataPoints={allData.points}
                 naiveLine={allData.naiveLine}
                 correctedLine={showCorrect ? allData.correctedLine : []}
               />
+            </Col>
+            <Col lg={{ span: 12, offset: 0 }} xl={{ span: 4, offset: 0 }}>
+              <div style={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'flex-start',
+                marginTop: '20%'
+              }}>
+                <p>
+                  {`Naive Regression: f(x) = ${naiveLine[0].toFixed(2)}x + ${naiveLine[1].toFixed(2)}`}
+                </p>
+                <p>
+                  {showCorrect ? `Corrected Regression: f(x) = ${correctedLine[0].toFixed(2)}x + ${correctedLine[1].toFixed(2)}` : ''}
+                </p>
+              </div>
             </Col>
           </Row>
           <Row>

--- a/src/components/OmittedVariableBias/OmittedVariableBias.js
+++ b/src/components/OmittedVariableBias/OmittedVariableBias.js
@@ -8,8 +8,7 @@ import PD from 'probability-distributions';
 import _ from 'lodash';
 import InputSlider from '../InputSlider.js';
 import { linearRegression } from '../../lib/stats-utils.js';
-import { InlineMath, BlockMath } from 'react-katex';
-//import TeX from '@matejmazur/react-katex';
+import { InlineMath } from 'react-katex';
 
 export default function OmittedVariableBias() {
   const [beta, setBeta] = useState(3);


### PR DESCRIPTION
<img width="1342" alt="Screen Shot 2022-06-06 at 13 39 01" src="https://user-images.githubusercontent.com/49931122/172215203-070f9c91-a911-4e72-9c5a-44dfbb5a2886.png">

Resolves issue #280 

[Feature]
I've added the presentation of regression equation to the right of the chart. It adapts to the newest regression line when new examples are generated. The equation for Corrected Regression is shown / hidden in sync with the regression line on the chart.

[Questions]
1. Is the expression format "f(x)=2.79x+56.89" the correct one for the regression equation in this context?
2. Currently, on every re-generation of examples, the Corrected Regression line is hidden by default. Is it a feature wanted? Do we want to keep it that way?

Please let me know if there's any problem running the branch "OVBequations" locally, or any changes you would like me to make :)